### PR TITLE
unpack list into a tuple constructor for python-3.7

### DIFF
--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -124,15 +124,15 @@ class GPTModel(MegatronModule):
             get_key_value=get_key_value)
 
         if self.post_process:
-            return post_language_model_processing(
+            return (post_language_model_processing(
                 lm_output, labels,
                 self.word_embeddings_weight(),
                 get_key_value,
                 self.parallel_output,
                 forward_method_parallel_output,
-                self.fp16_lm_cross_entropy), *moe_losses
+                self.fp16_lm_cross_entropy), *moe_losses)
         else:
-            return lm_output, *moe_losses
+            return (lm_output, *moe_losses)
 
     def state_dict_for_save_checkpoint(self, destination=None, prefix='',
                                        keep_vars=False):

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -405,9 +405,9 @@ class TransformerLanguageModel(MegatronModule):
         # similarity between two sequences by average pooling
         if not self.add_decoder or output_enc_hidden:
             if self.add_pooler and self.post_process:
-                return encoder_output, pooled_output, *moe_losses
+                return (encoder_output, pooled_output, *moe_losses)
             else:
-                return encoder_output, *moe_losses
+                return (encoder_output, *moe_losses)
 
         # Decoder Embedding
         dec_embedding_output = self.embedding(dec_input_ids,
@@ -421,9 +421,9 @@ class TransformerLanguageModel(MegatronModule):
                                       enc_dec_attn_mask=enc_dec_attn_mask)
 
         if self.add_pooler and self.post_process:
-            return decoder_output, encoder_output, pooled_output, *moe_losses
+            return (decoder_output, encoder_output, pooled_output, *moe_losses)
         else:
-            return decoder_output, encoder_output, *moe_losses
+            return (decoder_output, encoder_output, *moe_losses)
 
     def state_dict_for_save_checkpoint(self, destination=None, prefix='',
                                        keep_vars=False):


### PR DESCRIPTION
A number of statements in the megatron model are written as:
```
return encoder_output, pooled_output, *moe_losses
```
This syntax is valid starting with Python-3.8, but it throws the following syntax error for Python-3.7 users:
```
File "/path/to/megatron/model/language_model.py", line 408
  return encoder_output, pooled_output, *moe_losses
                                        ^
SyntaxError: invalid syntax
```
One fix that makes things work for both versions of Python is to surround the tuple arguments with parenthesis.  A similar pattern was already in the code here:

https://github.com/microsoft/Megatron-DeepSpeed/blob/2316a9c77ac4e0988f2997162dfeb9a25fc7e195/megatron/model/transformer.py#L770

Resolves https://github.com/microsoft/Megatron-DeepSpeed/issues/24