### PR TITLE
Add support for DS comms

### DIFF
--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import torch
+import deepspeed
 
 from .package_info import (
     __description__,
@@ -37,19 +38,19 @@ from .initialize  import initialize_megatron
 
 def print_rank_0(message):
     """If distributed is initialized, print only on rank 0."""
-    if torch.distributed.is_initialized():
-        if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.is_initialized():
+        if deepspeed.comm.get_rank() == 0:
             print(message, flush=True)
     else:
         print(message, flush=True)
 
 def is_last_rank():
-    return torch.distributed.get_rank() == (
-        torch.distributed.get_world_size() - 1)
+    return deepspeed.comm.get_rank() == (
+        deepspeed.comm.get_world_size() - 1)
 
 def print_rank_last(message):
     """If distributed is initialized, print only on last rank."""
-    if torch.distributed.is_initialized():
+    if deepspeed.comm.is_initialized():
         if is_last_rank():
             print(message, flush=True)
     else:

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -19,6 +19,7 @@ import time
 
 import numpy as np
 import torch
+import deepspeed
 
 from megatron import print_rank_0
 from megatron import mpu
@@ -53,7 +54,7 @@ class BlendableDataset(torch.utils.data.Dataset):
         helpers.build_blending_indices(self.dataset_index,
                                        self.dataset_sample_index,
                                        weights, num_datasets, self.size,
-                                       torch.distributed.get_rank() == 0)
+                                       deepspeed.comm.get_rank() == 0)
         print_rank_0('> elapsed time for building blendable dataset indices: '
                      '{:.2f} (sec)'.format(time.time() - start_time))
 

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -25,6 +25,7 @@ import collections
 
 import numpy as np
 import torch
+import deepspeed
 
 from megatron import (
     get_args,
@@ -662,7 +663,7 @@ def get_samples_mapping(indexed_dataset,
     indexmap_filename += '.npy'
 
     # Build the indexed mapping if not exist.
-    if torch.distributed.get_rank() == 0 and \
+    if deepspeed.comm.get_rank() == 0 and \
        not os.path.isfile(indexmap_filename):
         print(' > WARNING: could not find index map file {}, building '
               'the indices on rank 0 ...'.format(indexmap_filename))
@@ -672,7 +673,7 @@ def get_samples_mapping(indexed_dataset,
         assert indexed_dataset.sizes.dtype == np.int32
 
         # Build samples mapping
-        verbose = torch.distributed.get_rank() == 0
+        verbose = deepspeed.comm.get_rank() == 0
         start_time = time.time()
         print_rank_0(' > building sapmles index mapping for {} ...'.format(
             name))
@@ -700,11 +701,11 @@ def get_samples_mapping(indexed_dataset,
     # device_index=rank which is not the case for model
     # parallel case
     counts = torch.cuda.LongTensor([1])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
+    deepspeed.comm.all_reduce(counts, group=mpu.get_data_parallel_group())
+    deepspeed.comm.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
     assert counts[0].item() == (
-        torch.distributed.get_world_size() //
-        torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group()))
+        deepspeed.comm.get_world_size() //
+        deepspeed.comm.get_world_size(group=mpu.get_tensor_model_parallel_group()))
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -20,6 +20,7 @@ import time
 
 import numpy as np
 import torch
+import deepspeed
 
 from megatron import mpu, print_rank_0
 from megatron.data.blendable_dataset import BlendableDataset
@@ -212,7 +213,7 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     shuffle_idx_filename = _filename + '_shuffle_idx.npy'
 
     # Build the indexed mapping if not exist.
-    if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.get_rank() == 0:
         if (not os.path.isfile(doc_idx_filename)) or \
            (not os.path.isfile(sample_idx_filename)) or \
            (not os.path.isfile(shuffle_idx_filename)):
@@ -297,11 +298,11 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     # device_index=rank which is not the case for model
     # parallel case
     counts = torch.cuda.LongTensor([1])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
+    deepspeed.comm.all_reduce(counts, group=mpu.get_data_parallel_group())
+    deepspeed.comm.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
     assert counts[0].item() == (
-        torch.distributed.get_world_size() //
-        torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group()))
+        deepspeed.comm.get_world_size() //
+        deepspeed.comm.get_world_size(group=mpu.get_tensor_model_parallel_group()))
 
     # Load mappings.
     start_time = time.time()

--- a/megatron/data/realm_dataset_utils.py
+++ b/megatron/data/realm_dataset_utils.py
@@ -3,6 +3,7 @@ import time
 
 import numpy as np
 import torch
+import deepspeed
 
 from megatron import mpu, print_rank_0
 from megatron.data.dataset_utils import create_masked_lm_predictions, pad_and_convert_to_numpy
@@ -147,7 +148,7 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         assert block_dataset.sizes.dtype == np.int32
 
         # Build samples mapping
-        verbose = torch.distributed.get_rank() == 0
+        verbose = deepspeed.comm.get_rank() == 0
         start_time = time.time()
         print_rank_0(' > building samples index mapping for {} ...'.format(
             name))
@@ -178,8 +179,8 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
     # device_index=rank which is not the case for model
     # parallel case
     counts = torch.cuda.LongTensor([1])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    assert counts[0].item() == torch.distributed.get_world_size(
+    deepspeed.comm.all_reduce(counts, group=mpu.get_data_parallel_group())
+    assert counts[0].item() == deepspeed.comm.get_world_size(
         group=mpu.get_data_parallel_group())
 
     # Load indexed dataset.

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -20,6 +20,7 @@ import sys
 import time
 
 import torch
+import deepspeed
 
 from megatron.tokenizer import build_tokenizer
 from .arguments import parse_args
@@ -254,9 +255,9 @@ class Timers:
             elapsed_time = self.timers[name].elapsed(
                 reset=reset) * 1000.0 / normalizer
             string += ' | {}: {:.2f}'.format(name, elapsed_time)
-        if torch.distributed.is_initialized():
-            if torch.distributed.get_rank() == (
-                    torch.distributed.get_world_size() - 1):
+        if deepspeed.comm.is_initialized():
+            if deepspeed.comm.get_rank() == (
+                    deepspeed.comm.get_world_size() - 1):
                 print(string, flush=True)
         else:
             print(string, flush=True)

--- a/megatron/indexer.py
+++ b/megatron/indexer.py
@@ -1,6 +1,6 @@
 import sys
 import torch
-import torch.distributed as dist
+import deepspeed.comm as dist
 
 from megatron import get_args
 from megatron import mpu
@@ -112,7 +112,7 @@ class IndexBuilder(object):
         # This process signals to finalize its shard and then synchronize with
         # the other processes
         self.evidence_embedder_obj.save_shard()
-        torch.distributed.barrier()
+        deepspeed.comm.barrier()
         del self.model
 
         # rank 0 process builds the final copy
@@ -124,4 +124,4 @@ class IndexBuilder(object):
         self.evidence_embedder_obj.clear()
 
         # complete building the final copy
-        torch.distributed.barrier()
+        deepspeed.comm.barrier()

--- a/megatron/memory.py
+++ b/megatron/memory.py
@@ -15,6 +15,7 @@
 
 
 import torch
+import deepspeed
 
 
 # A dictionary of all the memory buffers allocated.
@@ -47,7 +48,7 @@ class MemoryBuffer:
 
     """
     def __init__(self, name, numel, dtype, track_usage):
-        if torch.distributed.get_rank() == 0:
+        if deepspeed.comm.get_rank() == 0:
             element_size = torch.tensor([], dtype=dtype).element_size()
             print('> building the {} memory buffer with {} num elements '
                   'and {} dtype ({:.1f} MB)...'.format(
@@ -119,7 +120,7 @@ class MemoryBuffer:
         """Print memory usage average over time. We would like this value
         to be as high as possible."""
         assert self.track_usage, 'You need to enable track usage.'
-        if torch.distributed.get_rank() == 0:
+        if deepspeed.comm.get_rank() == 0:
             print(' > usage of {} memory buffer: {:.2f} %'.format(
                 self.name, self.in_use_value * 100.0 / self.total_value),
                   flush=True)

--- a/megatron/model/biencoder_model.py
+++ b/megatron/model/biencoder_model.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import deepspeed
 import sys
 
 from megatron import get_args, print_rank_0
@@ -165,7 +166,7 @@ class BiEncoderModel(MegatronModule):
         checkpoint_name = get_checkpoint_name(args.bert_load, iteration, False)
         if mpu.get_data_parallel_rank() == 0:
             print('global rank {} is loading BERT checkpoint {}'.format(
-                torch.distributed.get_rank(), checkpoint_name))
+                deepspeed.comm.get_rank(), checkpoint_name))
 
         # Load the checkpoint.
         try:

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -166,7 +166,7 @@ class Embedding(MegatronModule):
         """
         if self.tokentype_embeddings is not None:
             raise Exception('tokentype embeddings is already initialized')
-        if torch.distributed.get_rank() == 0:
+        if deepspeed.comm.get_rank() == 0:
             print('adding embedding for {} tokentypes'.format(num_tokentypes),
                   flush=True)
         self.num_tokentypes = num_tokentypes

--- a/megatron/model/module.py
+++ b/megatron/model/module.py
@@ -18,6 +18,7 @@
 import torch
 from torch.autograd import Variable
 from torch.nn.parameter import Parameter
+import deepspeed
 
 from megatron import get_args
 from megatron import mpu
@@ -99,9 +100,9 @@ class MegatronModule(torch.nn.Module):
 
         # Ensure that first and last stages have the same initial parameter
         # values.
-        if torch.distributed.is_initialized():
+        if deepspeed.comm.is_initialized():
             if mpu.is_pipeline_first_stage() or mpu.is_pipeline_last_stage():
-                torch.distributed.all_reduce(self.word_embeddings_weight().data,
+                deepspeed.comm.all_reduce(self.word_embeddings_weight().data,
                                              group=mpu.get_embedding_group())
         else:
             print("WARNING! Distributed processes aren't initialized, so "

--- a/megatron/model/realm_model.py
+++ b/megatron/model/realm_model.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import deepspeed
 
 from megatron import get_args, print_rank_0
 from megatron.checkpointing import get_checkpoint_tracker_filename, get_checkpoint_name
@@ -127,7 +128,7 @@ class ICTBertModel(MegatronModule):
         checkpoint_name = get_checkpoint_name(args.bert_load, iteration, False)
         if mpu.get_data_parallel_rank() == 0:
             print('global rank {} is loading checkpoint {}'.format(
-                torch.distributed.get_rank(), checkpoint_name))
+                deepspeed.comm.get_rank(), checkpoint_name))
 
         try:
             state_dict = torch.load(checkpoint_name, map_location='cpu')

--- a/megatron/mpu/cross_entropy.py
+++ b/megatron/mpu/cross_entropy.py
@@ -15,6 +15,7 @@
 
 
 import torch
+import deepspeed
 
 from .initialize import get_tensor_model_parallel_group
 from .initialize import get_tensor_model_parallel_rank
@@ -29,8 +30,8 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
 
         # Maximum value along vocab dimension across all GPUs.
         logits_max = torch.max(vocab_parallel_logits, dim=-1)[0]
-        torch.distributed.all_reduce(logits_max,
-                                     op=torch.distributed.ReduceOp.MAX,
+        deepspeed.comm.all_reduce(logits_max,
+                                     op=deepspeed.comm.ReduceOp.MAX,
                                      group=get_tensor_model_parallel_group())
         # Subtract the maximum value.
         vocab_parallel_logits.sub_(logits_max.unsqueeze(dim=-1))
@@ -60,16 +61,16 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
         predicted_logits = predicted_logits_1d.view_as(target)
         predicted_logits[target_mask] = 0.0
         # All reduce is needed to get the chunks from other GPUs.
-        torch.distributed.all_reduce(predicted_logits,
-                                     op=torch.distributed.ReduceOp.SUM,
+        deepspeed.comm.all_reduce(predicted_logits,
+                                     op=deepspeed.comm.ReduceOp.SUM,
                                      group=get_tensor_model_parallel_group())
 
         # Sum of exponential of logits along vocab dimension across all GPUs.
         exp_logits = vocab_parallel_logits
         torch.exp(vocab_parallel_logits, out=exp_logits)
         sum_exp_logits = exp_logits.sum(dim=-1)
-        torch.distributed.all_reduce(sum_exp_logits,
-                                     op=torch.distributed.ReduceOp.SUM,
+        deepspeed.comm.all_reduce(sum_exp_logits,
+                                     op=deepspeed.comm.ReduceOp.SUM,
                                      group=get_tensor_model_parallel_group())
 
         # Loss = log(sum(exp(logits))) - predicted-logit.

--- a/megatron/mpu/data.py
+++ b/megatron/mpu/data.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import torch
+import deepspeed
 
 from .initialize import get_tensor_model_parallel_group
 from .initialize import get_tensor_model_parallel_rank
@@ -47,7 +48,7 @@ def _build_key_size_numel_dictionaries(keys, data):
 
     # Move to GPU and broadcast.
     sizes_cuda = torch.cuda.LongTensor(sizes)
-    torch.distributed.broadcast(sizes_cuda, get_tensor_model_parallel_src_rank(),
+    deepspeed.comm.broadcast(sizes_cuda, get_tensor_model_parallel_src_rank(),
                                 group=get_tensor_model_parallel_group())
 
     # Move back to cpu and unpack.
@@ -101,7 +102,7 @@ def broadcast_data(keys, data, datatype):
                                    dtype=datatype)
 
     # Broadcast
-    torch.distributed.broadcast(flatten_data, get_tensor_model_parallel_src_rank(),
+    deepspeed.comm.broadcast(flatten_data, get_tensor_model_parallel_src_rank(),
                                 group=get_tensor_model_parallel_group())
 
     # Unpack

--- a/megatron/mpu/mappings.py
+++ b/megatron/mpu/mappings.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import torch
+import deepspeed
 
 from .initialize import get_tensor_model_parallel_group, get_tensor_model_parallel_world_size, get_tensor_model_parallel_rank
 from .utils import split_tensor_along_last_dim
@@ -27,7 +28,7 @@ def _reduce(input_):
         return input_
 
     # All-reduce.
-    torch.distributed.all_reduce(input_, group=get_tensor_model_parallel_group())
+    deepspeed.comm.all_reduce(input_, group=get_tensor_model_parallel_group())
 
     return input_
 
@@ -65,7 +66,7 @@ def _gather(input_):
 
     tensor_list = [torch.empty_like(input_) for _ in range(world_size)]
     tensor_list[rank] = input_
-    torch.distributed.all_gather(tensor_list, input_, group=get_tensor_model_parallel_group())
+    deepspeed.comm.all_gather(tensor_list, input_, group=get_tensor_model_parallel_group())
 
     # Note: torch.cat already creates a contiguous tensor.
     output = torch.cat(tensor_list, dim=last_dim).contiguous()

--- a/megatron/mpu/tests/test_data.py
+++ b/megatron/mpu/tests/test_data.py
@@ -21,12 +21,13 @@ import torch
 import functools
 import operator
 import sys
+import deepspeed
 sys.path.append("../..")
 
 
 def test_broadcast_data(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.get_rank() == 0:
         print('> testing broadcast_data with model parallel size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -71,15 +72,15 @@ def test_broadcast_data(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_tensor_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    deepspeed.comm.barrier()
+    if deepspeed.comm.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 if __name__ == '__main__':
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    world_size = deepspeed.comm.get_world_size()
 
     tensor_model_parallel_size = 1
     while tensor_model_parallel_size <= world_size:

--- a/megatron/mpu/tests/test_random.py
+++ b/megatron/mpu/tests/test_random.py
@@ -17,13 +17,14 @@ from commons import print_separator
 from commons import initialize_distributed
 import mpu
 import torch
+import deepspeed
 import sys
 sys.path.append("../..")
 
 
 def test_set_cuda_rng_state(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.get_rank() == 0:
         print('> testing set_rng_state with size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -51,7 +52,7 @@ def test_set_cuda_rng_state(tensor_model_parallel_size):
     new_rng_state = torch.cuda.get_rng_state()
     max_diff = new_rng_state.sub(rng_state).max()
     print('   max diff in rng state (should be non-zero) on global rank {}: {}'.
-          format(torch.distributed.get_rank(), max_diff))
+          format(deepspeed.comm.get_rank(), max_diff))
     assert max_diff > 0
 
     # Reset the rng state and do the same stuff.
@@ -66,26 +67,26 @@ def test_set_cuda_rng_state(tensor_model_parallel_size):
     # Results should be the same
     error = result_2.sub(result_1).abs().max()
     print('   max error in generated tensors (should be zero) on '
-          'global rank {}: {}'.format(torch.distributed.get_rank(), error))
+          'global rank {}: {}'.format(deepspeed.comm.get_rank(), error))
     assert error < 1.0e-6
 
     # Input state should have remained intact.
     error = rng_state.sub(rng_state_copy).max()
     print('   max error in rng state (should be zero) on global rank {}: {}'.
-          format(torch.distributed.get_rank(), error))
+          format(deepspeed.comm.get_rank(), error))
     assert error == 0
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    deepspeed.comm.barrier()
+    if deepspeed.comm.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 def test_cuda_rng_tracker(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.get_rank() == 0:
         print('> testing cuda rng tracker with size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -133,14 +134,14 @@ def test_cuda_rng_tracker(tensor_model_parallel_size):
     diff = result_11.sub(result_21).abs().max()
     diff = min(diff, result_12.sub(result_22).abs().max())
     print('   max diff in generated tensors (should be non-zero) on '
-          'global rank {}: {}'.format(torch.distributed.get_rank(), diff))
+          'global rank {}: {}'.format(deepspeed.comm.get_rank(), diff))
     assert diff > 1.0e-6
     error = max(result_11.sub(target_11).abs().max(),
                 result_12.sub(target_12).abs().max())
     error = max(error, result_21.sub(target_21).abs().max())
     error = max(error, result_22.sub(target_22).abs().max())
     print('   max error in generated tensors (should be zero) on '
-          'global rank {}: {}'.format(torch.distributed.get_rank(), error))
+          'global rank {}: {}'.format(deepspeed.comm.get_rank(), error))
     assert error < 1.0e-6
 
     # Reset the tracker
@@ -149,14 +150,14 @@ def test_cuda_rng_tracker(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    deepspeed.comm.barrier()
+    if deepspeed.comm.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 def test_model_parallel_cuda_manual_seed(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.get_rank() == 0:
         print('> testing model parallel cuda manual seed with size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -175,15 +176,15 @@ def test_model_parallel_cuda_manual_seed(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    deepspeed.comm.barrier()
+    if deepspeed.comm.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 if __name__ == '__main__':
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    world_size = deepspeed.comm.get_world_size()
 
     tensor_model_parallel_size = 1
     while tensor_model_parallel_size <= world_size:

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -19,6 +19,7 @@ from abc import ABC
 from abc import abstractmethod
 
 import torch
+import deepspeed
 
 from apex.multi_tensor_apply import multi_tensor_applier
 import amp_C
@@ -330,8 +331,8 @@ class Float16OptimizerWithFloat16Params(MegatronOptimizer):
         torch._amp_foreach_non_finite_check_and_unscale_(
             main_grads, self.found_inf, self.grad_scaler.inv_scale)
         # Update across all model parallel instances.
-        torch.distributed.all_reduce(self.found_inf,
-                                     op=torch.distributed.ReduceOp.MAX,
+        deepspeed.comm.all_reduce(self.found_inf,
+                                     op=deepspeed.comm.ReduceOp.MAX,
                                      group=mpu.get_model_parallel_group())
 
         # Check for nan.

--- a/megatron/p2p_communication.py
+++ b/megatron/p2p_communication.py
@@ -35,7 +35,7 @@ def _communicate(tensor_send_next, tensor_send_prev, recv_prev, recv_next,
                    previous rank.
         recv_next: boolean for whether tensor should be received from
                    next rank.
-        use_ring_exchange: boolean for whether torch.distributed.ring_exchange()
+        use_ring_exchange: boolean for whether deepspeed.comm.ring_exchange()
                            API should be used.
 
     Returns:

--- a/pretrain_ict.py
+++ b/pretrain_ict.py
@@ -17,7 +17,7 @@
 import math
 
 import torch
-import torch.distributed as dist
+import deepspeed.comm as dist
 import torch.nn.functional as F
 
 from megatron import get_args
@@ -43,8 +43,8 @@ def pretrain_ict_model_provider():
 def get_group_world_size_rank():
 
     group = mpu.get_data_parallel_group()
-    rank = torch.distributed.get_rank(group=group)
-    world_size = torch.distributed.get_world_size(group=group)
+    rank = deepspeed.comm.get_rank(group=group)
+    world_size = deepspeed.comm.get_world_size(group=group)
 
     return group, rank, world_size
 
@@ -58,7 +58,7 @@ class AllgatherFromDataParallelRegion(torch.autograd.Function):
 
         tensor_list = [torch.empty_like(input_) for _ in range(world_size)]
         tensor_list[rank] = input_
-        torch.distributed.all_gather(tensor_list, input_, group=group)
+        deepspeed.comm.all_gather(tensor_list, input_, group=group)
 
         output = torch.cat(tensor_list, dim=0).contiguous()
 

--- a/tasks/eval_harness/evaluate.py
+++ b/tasks/eval_harness/evaluate.py
@@ -20,6 +20,7 @@ import numpy as np
 import time
 
 import torch
+import deepspeed
 from megatron import get_args
 from megatron import print_rank_0
 from megatron import get_tokenizer
@@ -346,7 +347,7 @@ def load_ds_checkpoint_and_setup_megatron(extra_args_provider):
     megatron.global_vars._GLOBAL_ARGS = args
 
     initialize_megatron()
-    torch.distributed.barrier()
+    deepspeed.comm.barrier()
 
     # Initializing megatron will update eg. tokenizer size. Override again.
     override_args(args, cp_args, skip_keys, skip_if_specified)
@@ -384,7 +385,7 @@ def load_ds_checkpoint_and_setup_megatron(extra_args_provider):
     if args.eval_fp32:
         model = model.float()
 
-    torch.distributed.barrier()
+    deepspeed.comm.barrier()
     return model
 
 def tasks_args(parser):

--- a/tasks/eval_utils.py
+++ b/tasks/eval_utils.py
@@ -20,6 +20,7 @@ import time
 from functools import partial
 
 import torch
+import deepspeed
 
 from megatron import get_args
 from megatron import print_rank_last, is_last_rank
@@ -173,7 +174,7 @@ def calculate_correct_answers(name, model, dataloader,
     # Reduce.
     if mpu.is_pipeline_last_stage():
         unreduced = torch.cuda.LongTensor([correct, total])
-        torch.distributed.all_reduce(unreduced,
+        deepspeed.comm.all_reduce(unreduced,
                                      group=mpu.get_data_parallel_group())
 
         # Print on screen.

--- a/tasks/vision/eval_utils.py
+++ b/tasks/vision/eval_utils.py
@@ -23,6 +23,7 @@ from megatron import mpu
 from tasks.vision.finetune_utils import build_data_loader
 from tasks.vision.finetune_utils import process_batch
 from torchvision import datasets, transforms
+import deepspeed
 
 
 def accuracy_func_provider():
@@ -87,7 +88,7 @@ def calculate_correct_answers(model, dataloader, epoch):
 
     # Reduce.
     unreduced = torch.cuda.LongTensor([correct, total])
-    torch.distributed.all_reduce(unreduced, group=mpu.get_data_parallel_group())
+    deepspeed.comm.all_reduce(unreduced, group=mpu.get_data_parallel_group())
 
     # Print on screen.
     correct_ans = unreduced[0].item()

--- a/tasks/zeroshot_gpt/evaluate.py
+++ b/tasks/zeroshot_gpt/evaluate.py
@@ -18,6 +18,7 @@
 import math
 
 import torch
+import deepspeed
 
 from megatron import get_args
 from megatron import print_rank_0, is_last_rank
@@ -143,7 +144,7 @@ def evaluate(data_loader, model, eval_metric):
 
             # Reduce across processes.
             if mpu.is_pipeline_last_stage():
-                torch.distributed.all_reduce(output,
+                deepspeed.comm.all_reduce(output,
                                              group=mpu.get_data_parallel_group())
 
                 total_output += output

--- a/tools/generate_samples_gpt.py
+++ b/tools/generate_samples_gpt.py
@@ -145,7 +145,7 @@ def main():
     
     
     #if torch.cuda.current_device() == 0:
-    if torch.distributed.get_rank() == 0:
+    if deepspeed.comm.get_rank() == 0:
         print_latency(latencies)
         print_latency(model_latencies, "model_latencies")
         print_latency(single_token_latency, "single_token_latency")


### PR DESCRIPTION
DeepSpeed no longer directly calls `torch.distributed`. This commit updates Megatron-DeepSpeed to adhere to the new `deepspeed.comm` interface.