### PR TITLE
[fix]Solve checkpoint loading err with megatron bert_model 

### DIFF
--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -234,3 +234,22 @@ class BertModel(MegatronModule):
         if self.post_process and not self.pre_process:
             self.word_embeddings.load_state_dict(
                 state_dict[self._word_embeddings_for_head_key], strict=strict)
+
+    def state_dict(self, destination=None, prefix='',
+                                       keep_vars=False):
+        state_dict_ = {}
+        state_dict_[self._language_model_key] \
+            = self.language_model.state_dict_for_save_checkpoint(
+            destination, prefix, keep_vars)
+        if self.post_process:
+            state_dict_[self._lm_head_key] \
+                = self.lm_head.state_dict_for_save_checkpoint(
+                destination, prefix, keep_vars)
+        if self.post_process and self.add_binary_head:
+            state_dict_[self._binary_head_key] \
+                = self.binary_head.state_dict(destination, prefix, keep_vars)
+        # Save word_embeddings.
+        if self.post_process and not self.pre_process:
+            state_dict_[self._word_embeddings_for_head_key] \
+                = self.word_embeddings.state_dict(destination, prefix, keep_vars)
+        return state_dict_


### PR DESCRIPTION
When enabling deepspeed, there's error when loading checkpoints created by deepspeed. The error message is as follows:
![image](https://user-images.githubusercontent.com/15059072/177519428-f2984984-107d-4f0b-b716-058fe8acd841.png)
It can be fixed by adding the same dict as Megatron does.
