### PR TITLE
BERT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ## Megatron-DeepSpeed
-DeepSpeed version of NVIDIA's Megatron-LM that adds additional support for several features such as MoE model training, Curriculum Learning, 3D Parallelism, and others.
+DeepSpeed version of NVIDIA's Megatron-LM that adds additional support for several features such as MoE model training, Curriculum Learning, 3D Parallelism, and others. The ```Megatron-DeepSpeed/examples/``` folder includes example scripts about the features supported by DeepSpeed.
 
 ### Run on Azure and AzureML
 To try out DeepSpeed on Azure, this fork of Megatron offers easy-to-use recipes and bash scripts. We strongly recommend to start with AzureML recipe in the ```examples/azureml``` folder. If you have a custom infrastructure (e.g. HPC clusters) or Azure VM based environment, please refer to the bash scripts in the ```examples/azure``` folder. 
 
+Below is Megatron-LM's original README:
 ------
 
 Megatron ([1](https://arxiv.org/pdf/1909.08053.pdf) and [2](https://arxiv.org/pdf/2104.04473.pdf)) is a large, powerful transformer developed by the Applied Deep Learning Research team at NVIDIA. This repository is for ongoing research on training large transformer language models at scale. We developed efficient, model-parallel (tensor and pipeline), and multi-node pre-training of transformer based models such as [GPT](https://arxiv.org/abs/2005.14165), [BERT](https://arxiv.org/pdf/1810.04805.pdf), and [T5](https://arxiv.org/abs/1910.10683) using mixed precision.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 ## Recipes and Scripts
 
+Please note that some of the script examples (e.g., pretrain_*.sh directly under ```Megatron-DeepSpeed/examples/``` folder) are from the original NVIDIA's Megatron-LM and does not have DeepSpeed integration (scripts with DeepSpeed integration should include the ```deepspeed``` keyword). Below we list various examples that do have DeepSpeed integration.
+
 ### Azure
 
 We strongly recommend to start with AzureML recipe in the ```azureml``` folder.
@@ -8,8 +10,16 @@ If you have a custom infrastructure (e.g. HPC clusters) or Azure VM and VMSS bas
 
 ### MoE
 
-Please see the ```MoE``` folder for different training recipes and scripts for Mixture-of-expert based models. 
+Please see the ```MoE``` folder for different training recipes and scripts for Mixture-of-expert based models and dense models. These recipes are for GPT-style NLG models.
 
 ### Curriculum Learning
 
-Curriculum learning recipes are in the ```curriculum_learning``` folder. Please refer to the detailed tutorials linked inside. 
+Curriculum learning recipes are in the ```curriculum_learning``` folder. Please refer to the detailed tutorials linked inside. These recipes are for GPT-style NLG models.
+
+### Model Compression
+
+The ```compression``` folder includes examples about layer reduction for task-agnostic compression. Please refer to [this tutorial](https://www.deepspeed.ai/tutorials/model-compression/#11-layer-reduction) about the DeepSpeed Model Compression Library. These recipes are for GPT-style NLG models.
+
+### BERT example
+
+The ```bert_with_pile``` folder includes examples about BERT-style model pre-training (using the public Pile data or user's own data) with DeepSpeed integration. Please refer to the readme in the folder for tutorial.

--- a/examples/bert_with_pile/README.md
+++ b/examples/bert_with_pile/README.md
@@ -1,0 +1,23 @@
+This ```bert_with_pile``` folder includes examples about BERT pre-training (using [the public Pile data](https://github.com/EleutherAI/the-pile) or user's own data) with DeepSpeed integration. We also provide scripts about preprocessing Pile data and MNLI finetuning.
+
+## Data preprocessing
+```prepare_pile_data.py``` is the script for downloading, decompressing, and preprocessing [the public Pile data](https://github.com/EleutherAI/the-pile). Users can also modify this script to preprocess their own training data.
+
+## BERT pre-training
+```ds_pretrain_bert.sh``` is the script for BERT pre-training integrated with DeepSpeed, supporting [ZeRO](https://www.deepspeed.ai/tutorials/zero/) together with Megatron's tensor-slicing model parallelism. The training hyperparameters follow the [Megatron paper](https://arxiv.org/abs/1909.08053). Note that the pipeline parallelism is currently not supported: DeepSpeed's pipeline parallelism is only integrated with the GPT case, and currently DeepSpeed is not integrated with Megatron's own pipeline parallelism.
+
+As a reference performance number, our measurements show that our example is able to achieve a throughput up to 145 TFLOPs per GPU when pre-training a 1.3B BERT model (with ZeRO stage-1, without model parallelism, with 64 NVIDIA A100 GPUs, with batch size 4096 (64 per GPU), with activation checkpointing).
+
+One thing to note is that this pre-training recipe is NOT a strict reproduction of the [original BERT paper](https://arxiv.org/abs/1810.04805): the Pile data is larger than the data used in original BERT (and the data used by Megatron paper); Megatron-LM introduces some changes to the BERT model (see details in [Megatron paper](https://arxiv.org/abs/1909.08053)); the training hyperparameters are also different. Overall these differences lead to longer training time but also better model quality than original BERT (see MNLI score below), and supporting large model scale by the combination of ZeRO and model parallelism. If you don't have enough computation budget, we recommend to reduce the total training iterations (```train_iters``` in the script) and potentially increase the learning rate at the same time. If you want to strictly reproduce original BERT, we recommend to use our [another BERT example](https://github.com/microsoft/DeepSpeedExamples/tree/master/bing_bert).
+
+## BERT MNLI fine-tuning
+```ds_finetune_bert_mnli.sh``` is the script for BERT MNLI fine-tuning, following the hyperparameters in the [Megatron paper](https://arxiv.org/abs/1909.08053). As a reference, table below present the scores using the model pre-trained based on the script above, comparing with the scores of original BERT and Megatron paper's BERT. Our BERT-Large's score is slightly lower than Megatron paper's, mainly due to the different data we used (Pile data is much diverse and larger than the data in Megatron paper, which potentially has negative effect on small million-scale models).
+
+| MNLI dev set accuracy | **MNLI-m** | **MNLI-mm** |
+| ---------- |---------- |---------- |
+| BERT-Base, [original BERT](https://arxiv.org/abs/1810.04805) | 84.6 | 83.4 |
+| BERT-Base, ours (median on 5 seeds) | 86.1 | 86.1 |
+| BERT-Large, [original BERT](https://arxiv.org/abs/1810.04805) | 86.7 | 85.9 |
+| BERT-Large, [Megatron paper](https://arxiv.org/abs/1909.08053) | 89.7 | 90.0 |
+| BERT-Large, ours (median on 5 seeds) | 89.1 | 89.6 |
+

--- a/examples/bert_with_pile/ds_config_bert_TEMPLATE.json
+++ b/examples/bert_with_pile/ds_config_bert_TEMPLATE.json
@@ -1,0 +1,28 @@
+{
+  "train_batch_size" : CONFIG_BATCH_SIZE,
+  "train_micro_batch_size_per_gpu": CONFIG_MBSIZE,
+  "steps_per_print": LOG_INTERVAL,
+
+  "zero_optimization": {
+    "stage": ZERO_STAGE,
+    "elastic_checkpoint": true
+  },
+
+  "gradient_clipping": 1.0,
+  "prescale_gradients": PRESCALE_GRAD,
+
+  "fp16": {
+    "enabled": CONFIG_FP16_ENABLED,
+    "loss_scale": 0,
+    "loss_scale_window": 500,
+    "hysteresis": 2,
+    "min_loss_scale": 1,
+    "initial_scale_power": 11
+  },
+
+  "bf16": {
+    "enabled": CONFIG_BF16_ENABLED
+  },
+
+  "wall_clock_breakdown" : false
+}

--- a/examples/bert_with_pile/ds_finetune_bert_mnli.sh
+++ b/examples/bert_with_pile/ds_finetune_bert_mnli.sh
@@ -1,0 +1,150 @@
+seed=1234
+pretrained_checkpoint="/blob/users/conglli/project/bert_with_pile/checkpoint/bert-pile-0.336B-iters-2M-lr-1e-4-min-1e-5-wmup-10000-dcy-2M-sty-linear-gbs-1024-mbs-16-gpu-64-zero-0-mp-1-pp-1-nopp"
+
+###############################################################################
+### Main configs
+### The main configs are from Megatron-LM paper
+### https://arxiv.org/abs/1909.08053. Choose based on your desired model size
+### or build your own configs.
+seq_len=512
+
+## From Table 6 in https://arxiv.org/abs/1909.08053.
+task="MNLI"
+global_batch_size=128
+lr=1e-5
+epochs=10
+
+train_data="/blob/data/GlueData/MNLI/train.tsv"
+valid_data="/blob/data/GlueData/MNLI/dev_matched.tsv \
+            /blob/data/GlueData/MNLI/dev_mismatched.tsv"
+
+## Adjust based on number of GPUs.
+batch_size=16
+
+## BERT 110M (same config as original BERT-Base model)
+## This config is not included in Megatron-LM paper
+# model_size=0.11
+# num_layers=12
+# hidden_size=768
+# num_attn_heads=12
+
+## BERT 336M (same config as original BERT-Large model)
+model_size=0.336
+num_layers=24
+hidden_size=1024
+num_attn_heads=16
+
+## BERT 1.3B
+# model_size=1.3
+# num_layers=24
+# hidden_size=2048
+# num_attn_heads=32
+
+## BERT 3.9B
+# model_size=3.9
+# num_layers=48
+# hidden_size=2560
+# num_attn_heads=40
+###############################################################################
+### Parallelism configs
+## Model parallelism, 1 is no MP
+mp_size=1
+
+## Pipeline parallelism. To disable PP, set pp_size to 1 and no_pp to true.
+## Currently pipeline parallelism is not supported for BERT model: DeepSpeed's
+## pipeline parallelism is only integrated with the GPT case, and currently
+## DeepSpeed is not integrated with Megatron's own pipeline parallelism.
+pp_size=1
+no_pp="true"
+
+## ZeRO stage
+zero_stage=0
+###############################################################################
+### Misc configs
+log_interval=10
+eval_iters=50
+eval_interval=100
+save_interval=500000
+
+## Activation checkpointing saves GPU memory, but reduces training speed
+# activation_checkpoint="true"
+activation_checkpoint="false"
+###############################################################################
+vocab_file="bert-large-uncased-vocab.txt"
+if [ ! -f "$vocab_file" ]; then
+    wget https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-vocab.txt
+fi
+
+jobname="${task}-bsz${global_batch_size}-lr${lr}-epochs${epochs}-seed${seed}"
+checkpoint_path="${pretrained_checkpoint}-finetune/${jobname}"
+mkdir -p ${checkpoint_path}
+
+template_json="ds_config_bert_TEMPLATE.json"
+config_json="ds_config_bert_bsz${global_batch_size}_mbsz${batch_size}_log${log_interval}_zero${zero_stage}.json"
+if [[ $zero_stage -gt 0 ]]; then
+sed "s/CONFIG_BATCH_SIZE/${global_batch_size}/" ${template_json} \
+    | sed "s/CONFIG_MBSIZE/${batch_size}/" \
+    | sed "s/LOG_INTERVAL/${log_interval}/" \
+    | sed "s/ZERO_STAGE/${zero_stage}/" \
+    | sed "s/PRESCALE_GRAD/false/" \
+    | sed "s/CONFIG_FP16_ENABLED/true/" \
+    | sed "s/CONFIG_BF16_ENABLED/false/" \
+      > ${config_json}
+else
+sed "s/CONFIG_BATCH_SIZE/${global_batch_size}/" ${template_json} \
+    | sed "s/CONFIG_MBSIZE/${batch_size}/" \
+    | sed "s/LOG_INTERVAL/${log_interval}/" \
+    | sed "s/ZERO_STAGE/${zero_stage}/" \
+    | sed "s/PRESCALE_GRAD/true/" \
+    | sed "s/CONFIG_FP16_ENABLED/true/" \
+    | sed "s/CONFIG_BF16_ENABLED/false/" \
+      > ${config_json}
+fi
+
+options=" \
+    --finetune \
+    --deepspeed \
+    --deepspeed_config ${config_json} \
+    --zero-stage ${zero_stage} \
+    --task ${task} \
+    --seed ${seed} \
+    --train-data ${train_data} \
+    --valid-data ${valid_data} \
+    --tokenizer-type BertWordPieceLowerCase \
+    --vocab-file ${vocab_file} \
+    --epochs ${epochs} \
+    --pretrained-checkpoint ${pretrained_checkpoint} \
+    --tensor-model-parallel-size ${mp_size} \
+    --pipeline-model-parallel-size ${pp_size} \
+    --num-layers ${num_layers} \
+    --hidden-size ${hidden_size} \
+    --num-attention-heads ${num_attn_heads} \
+    --global-batch-size ${global_batch_size} \
+    --micro-batch-size ${batch_size} \
+    --lr ${lr} \
+    --lr-decay-style linear \
+    --lr-warmup-fraction 0.065 \
+    --seq-length ${seq_len} \
+    --max-position-embeddings ${seq_len} \
+    --save-interval ${save_interval} \
+    --save ${checkpoint_path} \
+    --log-interval ${log_interval} \
+    --eval-interval ${eval_interval} \
+    --eval-iters ${eval_iters} \
+    --weight-decay 1.0e-1 \
+    --fp16"
+
+if [ "${activation_checkpoint}" = "true" ]; then
+options="${options} \
+    --checkpoint-activations \
+    --deepspeed-activation-checkpointing"
+fi
+
+if [[ "${no_pp}" = "true" ]]; then
+options="${options} \
+    --no-pipeline-parallel"
+fi
+
+# After the fine-tuning finishes, you can find the dev set accuracy numbers by
+# "grep -e "overall:" -e "metrics for" ${checkpoint_path}/output.log"
+deepspeed ../../tasks/main.py ${options} &> ${checkpoint_path}/output.log

--- a/examples/bert_with_pile/ds_pretrain_bert.sh
+++ b/examples/bert_with_pile/ds_pretrain_bert.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+dir=`pwd`
+###############################################################################
+### Main configs
+### The main configs are from Megatron-LM paper
+### https://arxiv.org/abs/1909.08053. Choose based on your desired model size
+### or build your own configs.
+seq_len=512
+global_batch_size=1024
+lr=1e-4
+min_lr=1e-5
+
+## init_std is the standard deviation for weight initialization. Usually larger
+## model needs lower std. Here we roughly follow a heuristic equation of
+## sqrt(1/3/hidden_size) from https://arxiv.org/pdf/2201.11990.pdf
+
+## In addition, we find that the 3.9B model (even after tuning init_std) has
+## NaN loss issue from the beginning thus unable to train. This is probably
+## because in this example we use the public Pile data, which is a more diverse
+## (and potentially more noisy) data than what used in Megatron paper. One
+## potential solution is only use the sub datasets in Pile that are also
+## used by Megatron paper.
+
+## BERT 110M (same config as original BERT-Base model)
+## This config is not included in Megatron-LM paper
+# model_size=0.11
+# num_layers=12
+# hidden_size=768
+# num_attn_heads=12
+# init_std=0.02
+
+## BERT 336M (same config as original BERT-Large model)
+model_size=0.336
+num_layers=24
+hidden_size=1024
+num_attn_heads=16
+init_std=0.02
+
+## BERT 1.3B
+# model_size=1.3
+# num_layers=24
+# hidden_size=2048
+# num_attn_heads=32
+# init_std=0.013
+
+## BERT 3.9B
+# model_size=3.9
+# num_layers=48
+# hidden_size=2560
+# num_attn_heads=40
+# init_std=0.011
+###############################################################################
+### Training duration configs
+## The main termination condition, original Megatron paper trains for 2M iters.
+train_iters_in_million=2
+train_iters=$((${train_iters_in_million} * 1000000))
+###############################################################################
+### lr configs
+## lr warmup and decay duration. Original Megatron paper uses 10000 warmup
+## iters. Decay iters is the same as train iters.
+lr_warmup_iters=10000
+lr_decay_iters_in_million=${train_iters_in_million}
+lr_decay_iters=$((${lr_decay_iters_in_million} * 1000000))
+lr_decay_style="linear"
+###############################################################################
+### Parallelism configs
+## Model parallelism, 1 is no MP
+mp_size=1
+
+## Pipeline parallelism. To disable PP, set pp_size to 1 and no_pp to true.
+## Currently pipeline parallelism is not supported for BERT model: DeepSpeed's
+## pipeline parallelism is only integrated with the GPT case, and currently
+## DeepSpeed is not integrated with Megatron's own pipeline parallelism.
+pp_size=1
+no_pp="true"
+
+## ZeRO stage
+zero_stage=0
+
+## Total number of GPUs. ds_ssh is from DeepSpeed library.
+num_gpus=$(($(ds_ssh nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)-2))
+num_gpus_pernode=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+num_node=$(( ${num_gpus} / ${num_gpus_pernode} ))
+## Data parallel size.
+dp_size=$(( ${num_gpus} / ${pp_size} / ${mp_size} ))
+
+## Micro batch size per GPU
+## Make sure that batch_size <= global_batch_size*pp_size*mp_size/num_gpus
+## Below batch_size calculation assumes the case without gradient accumulation.
+## Manually set it to a lower value if you hit out of memory during training.
+batch_size=$(( ${global_batch_size} / ${dp_size} ))
+###############################################################################
+### Misc configs
+log_interval=100
+eval_iters=10
+eval_interval=1000
+# num_save controls how frequent to save checkpoint. num_save=20 means that a
+# checkpoint will be saved every 5% of training. For longer training you would
+# want larger num_save to save more frequently, and vice versa.
+num_save=100
+save_interval=$((${train_iters} / ${num_save}))
+
+## Activation checkpointing saves GPU memory, but reduces training speed
+# activation_checkpoint="true"
+activation_checkpoint="false"
+
+## Whether or not log optimizer states (norms, max abs values) to tensorboard.
+## This is not required for training and might save GPU memory when turned off.
+log_optimizer_state="true"
+###############################################################################
+### Output and data configs
+current_time=$(date "+%Y.%m.%d-%H.%M.%S")
+host="${HOSTNAME}"
+
+## Public the Pile dataset, see prepare_pile_data.py in the same directory
+## about how to download and preprocess the data.
+jobname="bert-pile"
+## For internal use. Change data_home to your own training data path.
+data_home="/vc_data_blob/users/conglli/the_pile_bert"
+if [[ "$host" == *"webxt"* ]]; then
+    data_home="/blob/data/the_pile_bert"
+fi
+data_path="${data_home}/pile_bert_train_text_sentence"
+
+vocab_path="bert-large-uncased-vocab.txt"
+if [ ! -f "$vocab_path" ]; then
+    wget https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-vocab.txt
+fi
+
+## Number of workers for dataloader. We found that for BERT pre-training,
+## num_workers will greatly affect data loading time and overall training
+## time. In our experiment with 64 GPUs, the performance reaches peak at
+## num_workers = 4 but it may differ depending on hardware. Also note that
+## larger num_workers add more CPU computation/memory overhead.
+num_workers=4
+
+jobname="${jobname}-${model_size}B-iters-${train_iters_in_million}M"
+jobname="${jobname}-lr-${lr}-min-${min_lr}-wmup-${lr_warmup_iters}-dcy-${lr_decay_iters_in_million}M-sty-${lr_decay_style}"
+jobname="${jobname}-gbs-${global_batch_size}-mbs-${batch_size}-gpu-${num_gpus}-zero-${zero_stage}-mp-${mp_size}-pp-${pp_size}"
+if [ "${no_pp}" = "true" ]; then
+    jobname="${jobname}-nopp"
+fi
+
+username=$(whoami)
+output_home="/vc_data_blob/users/${username}/project/bert_with_pile"
+if [[ "$host" == *"webxt"* ]]; then
+    output_home="/blob/users/${username}/project/bert_with_pile"
+fi
+log_path="${output_home}/log/"
+checkpoint_path="${output_home}/checkpoint/${jobname}"
+## Microsoft internal constraint: because tensorboard is logged by last rank,
+## it's better to put the path in NFS instead of Blob.
+tensorboard_dir="/vc_data/users/${username}/project/bert_with_pile/tensorboard/"
+tensorboard_path="${tensorboard_dir}${jobname}_${host}_${current_time}"
+mkdir -p ${log_path}
+mkdir -p ${checkpoint_path}
+mkdir -p ${tensorboard_path}
+###############################################################################
+data_options=" \
+    --vocab-file ${vocab_path} \
+    --data-path ${data_path} \
+    --data-impl mmap"
+
+megatron_options=" \
+    --override-lr-scheduler \
+    --adam-beta1 0.9 \
+    --adam-beta2 0.999 \
+    --init-method-std ${init_std} \
+    --tensor-model-parallel-size ${mp_size} \
+    --lr-decay-iters ${lr_decay_iters} \
+    --lr-warmup-iters ${lr_warmup_iters} \
+    --micro-batch-size ${batch_size} \
+    --global-batch-size ${global_batch_size} \
+    --num-layers ${num_layers} \
+    --hidden-size ${hidden_size} \
+    --num-attention-heads ${num_attn_heads} \
+    --seq-length ${seq_len} \
+    --max-position-embeddings ${seq_len} \
+    --train-iters ${train_iters} \
+    --lr ${lr} \
+    --min-lr ${min_lr} \
+    --lr-decay-style ${lr_decay_style} \
+    --split 949,50,1 \
+    --log-interval ${log_interval} \
+    --eval-interval ${eval_interval} \
+    --eval-iters ${eval_iters} \
+    --save-interval ${save_interval} \
+    --weight-decay 1e-2 \
+    --clip-grad 1.0 \
+    --num-workers ${num_workers} \
+    --fp16 \
+    --load ${checkpoint_path} \
+    --save ${checkpoint_path} \
+    --tensorboard-queue-size 1 \
+    --log-timers-to-tensorboard \
+    --log-batch-size-to-tensorboard \
+    --log-validation-ppl-to-tensorboard \
+    --tensorboard-dir ${tensorboard_path}"
+
+if [ "${activation_checkpoint}" = "true" ]; then
+megatron_options="${megatron_options} \
+    --checkpoint-activations"
+fi
+
+if [ "${log_optimizer_state}" = "true" ]; then
+megatron_options="${megatron_options} \
+    --log-optimizer-states-to-tensorboard"
+fi
+
+template_json="ds_config_bert_TEMPLATE.json"
+config_json="ds_config_bert_bsz${global_batch_size}_mbsz${batch_size}_log${log_interval}_zero${zero_stage}.json"
+if [[ $zero_stage -gt 0 ]]; then
+sed "s/CONFIG_BATCH_SIZE/${global_batch_size}/" ${template_json} \
+    | sed "s/CONFIG_MBSIZE/${batch_size}/" \
+    | sed "s/LOG_INTERVAL/${log_interval}/" \
+    | sed "s/ZERO_STAGE/${zero_stage}/" \
+    | sed "s/PRESCALE_GRAD/false/" \
+    | sed "s/CONFIG_FP16_ENABLED/true/" \
+    | sed "s/CONFIG_BF16_ENABLED/false/" \
+      > ${config_json}
+else
+sed "s/CONFIG_BATCH_SIZE/${global_batch_size}/" ${template_json} \
+    | sed "s/CONFIG_MBSIZE/${batch_size}/" \
+    | sed "s/LOG_INTERVAL/${log_interval}/" \
+    | sed "s/ZERO_STAGE/${zero_stage}/" \
+    | sed "s/PRESCALE_GRAD/true/" \
+    | sed "s/CONFIG_FP16_ENABLED/true/" \
+    | sed "s/CONFIG_BF16_ENABLED/false/" \
+      > ${config_json}
+fi
+
+deepspeed_options=" \
+    --deepspeed \
+    --deepspeed_config ${config_json} \
+    --zero-stage ${zero_stage} \
+    --pipeline-model-parallel-size ${pp_size}"
+
+if [[ "${no_pp}" = "true" ]]; then
+deepspeed_options="${deepspeed_options} \
+    --no-pipeline-parallel"
+fi
+
+if [ "${activation_checkpoint}" = "true" ]; then
+deepspeed_options="${deepspeed_options} \
+    --deepspeed-activation-checkpointing"
+fi
+
+## When saving checkpoint to a storage with cache, their could be consistency
+## issue of the pointer to latest checkpoint. Here we find the correct pointer
+## and broadcast it to all nodes.
+iteration_file="$checkpoint_path/latest_checkpointed_iteration.txt"
+iteration_file_2="$checkpoint_path/latest"
+iteration=0
+for (( node = 0; node <= num_node-1; node++ ))
+do
+    if $(ssh -q worker-"$node" "test -f \"$iteration_file\""); then
+        local_iteration=$(ssh -q worker-"$node" cat $iteration_file)
+        iteration=$(( ${local_iteration} > ${iteration} ? ${local_iteration} :  ${iteration} ))
+    fi
+done
+if [[ $iteration -gt 0 ]]; then
+    iteration_2="global_step${iteration}"
+    ds_ssh "echo $iteration > $iteration_file"
+    ds_ssh "echo $iteration_2 > $iteration_file_2"
+fi
+
+deepspeed ${dir}/../../pretrain_bert.py ${megatron_options} ${data_options} ${deepspeed_options} &>> ${log_path}/${jobname}_${host}_${current_time}.log

--- a/examples/bert_with_pile/prepare_pile_data.py
+++ b/examples/bert_with_pile/prepare_pile_data.py
@@ -1,0 +1,128 @@
+import zstandard
+import sys
+import time
+import os
+
+import sys
+sys.path.insert(1, '../../')
+from megatron.data import indexed_dataset
+
+def pile_download(download_url, file_path, i):
+    start = time.time()
+    zstd_file_path = f"{file_path}{i:02}.jsonl.zst"
+    download_path = f"{download_url}{i:02}.jsonl.zst"
+    if not os.path.exists(zstd_file_path):
+        os.system(f"wget -P {file_path} {download_path}")
+        print(f"Finished downloading chunk {i} in {time.time() - start} sec")
+
+def pile_decompress(download_url, file_path, i):
+    zstd_file_path = f"{file_path}{i:02}.jsonl.zst"
+    output_path = f"{file_path}{i:02}.jsonl"
+    if not os.path.exists(output_path):
+        if not os.path.exists(zstd_file_path):
+            pile_download(download_url, file_path, i)
+        start = time.time()
+        with open(zstd_file_path, 'rb') as compressed:
+            decomp = zstandard.ZstdDecompressor()
+            with open(output_path, 'wb') as destination:
+                decomp.copy_stream(compressed, destination)
+        os.remove(zstd_file_path)
+        print(f"Finished decompressing chunk {i} in {time.time() - start} sec")
+
+def pile_preprocess(download_url, file_path, vocab_file, num_workers, i):
+    json_file_path = f"{file_path}{i:02}.jsonl"
+    output_prefix = f"{file_path}pile_bert_train_{i:02}"
+    if not os.path.exists(f"{output_prefix}_text_sentence.idx"):
+        if not os.path.exists(json_file_path):
+            pile_decompress(download_url, file_path, i)
+        start = time.time()
+        cmd = f"python ../../tools/preprocess_data.py \
+                --input {json_file_path} \
+                --output-prefix {output_prefix} \
+                --vocab {vocab_file} \
+                --dataset-impl mmap \
+                --tokenizer-type BertWordPieceLowerCase \
+                --split-sentences \
+                --workers {num_workers} "
+        # It's possible to hit MemoryError during above cmd since the memory
+        # usage is proportional to num_workers. In this case we delete the
+        # incomplete output and user shall retry with smaller num_workers.
+        # Our experience show that chunk 6, 7, 9, 17, 18, 20, 21, 24, 27
+        # particularly have large memory usage.
+        if os.system(cmd) == 0: # Success
+            os.remove(json_file_path)
+        else:
+            print(f"Error: chunk {i} preprocessing got error, delete \
+                    incomplete output. If MemoryError appeared, please retry \
+                    with num_workers smaller than {num_workers}.")
+            if os.path.exists(f"{output_prefix}_text_sentence.idx"):
+                os.remove(f"{output_prefix}_text_sentence.idx")
+            if os.path.exists(f"{output_prefix}_text_sentence.bin"):
+                os.remove(f"{output_prefix}_text_sentence.bin")
+        print(f"Finished preprocessing chunk {i} in {time.time() - start} sec")
+
+def pile_merge(file_path):
+    start = time.time()
+    num_chunks = 30
+    vocab_size = 30524
+    for i in range(num_chunks):
+        output_prefix = f"{file_path}pile_bert_train_{i:02}"
+        assert os.path.exists(f"{output_prefix}_text_sentence.idx")
+        assert os.path.exists(f"{output_prefix}_text_sentence.bin")
+    builder = indexed_dataset.make_builder(
+        f"{file_path}pile_bert_train_text_sentence.bin", impl="mmap",
+        vocab_size=vocab_size)
+    for i in range(num_chunks):
+        chunk_file = f"{file_path}pile_bert_train_{i:02}_text_sentence"
+        print(f"Merging file {chunk_file}")
+        builder.merge_file_(chunk_file)
+    print("Finalizing merged file ...")
+    builder.finalize(f"{file_path}pile_bert_train_text_sentence.idx")
+    print(f"Finished merging in {time.time() - start} sec")
+    # After verifying the merged data with real training, you may want to
+    # delete the data chunks.
+    # for i in range(num_chunks):
+    #     output_prefix = f"{file_path}pile_bert_train_{i:02}"
+    #     os.remove(f"{output_prefix}_text_sentence.idx")
+    #     os.remove(f"{output_prefix}_text_sentence.bin")
+
+if __name__ == '__main__':
+    # Path to download and store all the output files during the whole process.
+    # Estimated max storage usage would be around 1.6 TB (or 780GB if skip the
+    # final merge). Memory usage is proportional to the num_workers below (can
+    # be as high as O(300GB) if num_workers is around 20).
+    file_path = "/blob/data/the_pile_bert/"
+    # The raw Pile data has 30 compressed .zst chunks. To run on single
+    # machine for all chunks, run "python prepare_pile_data.py range 0 30".
+    # You can also split and run on multiple machines to speed up, since
+    # processing one chunk can take hours. The whole process only uses CPU.
+    if sys.argv[1] == "merge":
+        # "python prepare_pile_data.py merge" means merge all 30 processed data
+        # chunks. Run it only after all 30 chunks are preprocessed. The memory
+        # usage during merge is about 600GB. If you don't have enough memory,
+        # one solution is to directly use the 30 data chunks as multiple
+        # datasets. See '--data-path' in
+        # github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/arguments.py
+        pile_merge(file_path)
+    else:
+        if sys.argv[1] == "range":
+            # "python prepare_pile_data.py range 0 30" means process chunk 0-29
+            selected_chunk = range(int(sys.argv[2]), int(sys.argv[3]))
+        else:
+            # "python prepare_pile_data.py 2 5 8" means process chunk 2, 5, 8
+            selected_chunk = [int(x) for x in sys.argv[1:]]
+        print("selected_chunk: ", selected_chunk)
+        # Number of process. Adjust based on your CPU/Memory.
+        num_workers = 20
+        # Where the raw Pile data can be downloaded. The url may change in
+        # future. Contact EleutherAI (https://github.com/EleutherAI/the-pile)
+        # if this url does not work.
+        download_url = "https://the-eye.eu/public/AI/pile/train/"
+        vocab_file = "bert-large-uncased-vocab.txt"
+        vocab_url = "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-vocab.txt"
+        if not os.path.exists(vocab_file):
+            os.system(f"wget {vocab_url}")
+        os.makedirs(file_path, exist_ok=True)
+
+        for i in selected_chunk:
+            pile_preprocess(download_url, file_path, vocab_file, num_workers, i)

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -174,6 +174,7 @@ def parse_args(extra_args_provider=None, defaults={},
     args.consumed_train_samples = 0
     args.consumed_valid_samples = 0
     args.consumed_train_tokens = 0
+    args.custom_token_counting = False
 
     # Iteration-based training.
     if args.train_iters:

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -273,7 +273,13 @@ def load_checkpoint(model, optimizer, lr_scheduler, load_arg='load', strict=True
     load_dir = getattr(args, load_arg)
 
     if args.deepspeed:
-        loaded_dir, state_dict = model[0].load_checkpoint(load_dir,load_module_strict=strict)
+        if args.finetune:
+            loaded_dir, state_dict = model[0].load_checkpoint(load_dir,
+                load_module_strict=strict, load_optimizer_states=False,
+                load_lr_scheduler_states=False, load_module_only=True)
+        else:
+            loaded_dir, state_dict = model[0].load_checkpoint(load_dir,
+                load_module_strict=strict)
         if loaded_dir is None:
             print_rank_0('WARNING: could not find the metadata file {} '.format(
                 load_dir))

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -10,6 +10,9 @@
 # Added document index to index file and made it accessible.
 #    An empty sentence no longer separates documents.
 
+# Some of the fixes/improvements are adopted from
+# https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/main/megatron/data/indexed_dataset.py
+
 from functools import lru_cache
 import os
 import shutil
@@ -295,13 +298,16 @@ class IndexedDatasetBuilder(object):
         index = IndexedDataset(another_file)
         assert index.dtype == self.dtype
 
+        doc_offset = len(self.sizes)
+
         begin = self.data_offsets[-1]
-        for offset in index.data_offsets[1:]:
-            self.data_offsets.append(begin + offset)
+        for data_offset in index.data_offsets[1:]:
+            self.data_offsets.append(begin + data_offset)
         self.sizes.extend(index.sizes)
         begin = self.dim_offsets[-1]
         for dim_offset in index.dim_offsets[1:]:
             self.dim_offsets.append(begin + dim_offset)
+        self.doc_idx.extend( (doc_offset + index.doc_idx)[1:] )
 
         with open(data_file_path(another_file), 'rb') as f:
             while True:
@@ -332,6 +338,38 @@ def _warmup_mmap_file(path):
             pass
 
 
+def exscan_from_cumsum_(arr):
+    # given an array holding the result of an inclusive scan (cumsum),
+    # convert to an exclusive scan (shift to the right)
+    # [10, 30, 35, 50] --> [0, 10, 30, 35]
+    if arr.size > 1:
+        arr[1:] = arr[:-1]
+    if arr.size > 0:
+        arr[0] = 0
+
+
+def get_pointers_with_total(sizes, elemsize, dtype):
+    """Return a numpy array of type np.dtype giving the byte offsets.
+
+    Multiplies values in the sizes array by elemsize (bytes),
+    and then computes an exclusive scan to get byte offsets.
+    Returns the total number of bytes as second item in a tuple.
+    """
+
+    # scale values in sizes array by elemsize to get sizes in bytes
+    pointers = np.array(sizes, dtype=dtype)
+    pointers *= elemsize
+    np.cumsum(pointers, axis=0, out=pointers)
+
+    # get total number of bytes from all sizes (last element)
+    bytes_last = pointers[-1] if len(sizes) > 0 else 0
+
+    # convert to byte offsets
+    exscan_from_cumsum_(pointers)
+
+    return pointers, bytes_last
+
+
 class MMapIndexedDataset(torch.utils.data.Dataset):
     class Index(object):
         _HDR_MAGIC = b'MMIDIDX\x00\x00'
@@ -349,28 +387,27 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
                     return self
 
                 @staticmethod
-                def _get_pointers(sizes):
-                    dtype_size = dtype().itemsize
-                    address = 0
-                    pointers = []
+                def _get_pointers(sizes, npdtype):
+                    """Return a numpy array of byte offsets given a list of sizes.
 
-                    for size in sizes:
-                        pointers.append(address)
-                        address += size * dtype_size
+                    Multiplies values in the sizes array by dtype size (bytes),
+                    and then computes an exclusive scan to get byte offsets.
+                    """
 
+                    # compute element sizes in bytes
+                    pointers, _ = get_pointers_with_total(sizes, dtype().itemsize, npdtype)
                     return pointers
 
                 def write(self, sizes, doc_idx):
-                    pointers = self._get_pointers(sizes)
-
                     self._file.write(struct.pack('<Q', len(sizes)))
                     self._file.write(struct.pack('<Q', len(doc_idx)))
 
-                    sizes = np.array(sizes, dtype=np.int32)
-                    self._file.write(sizes.tobytes(order='C'))
-                    del sizes
+                    sizes32 = np.array(sizes, dtype=np.int32)
+                    self._file.write(sizes32.tobytes(order='C'))
+                    del sizes32
 
-                    pointers = np.array(pointers, dtype=np.int64)
+                    pointers = self._get_pointers(sizes, np.int64)
+                    del sizes
                     self._file.write(pointers.tobytes(order='C'))
                     del pointers
 
@@ -515,6 +552,9 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
     def sizes(self):
         return self._index.sizes
 
+    def size(self, index):
+        return self._index.sizes[index]
+
     @property
     def doc_idx(self):
         return self._index.doc_idx
@@ -534,6 +574,10 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
         return (
             os.path.exists(index_file_path(path)) and os.path.exists(data_file_path(path))
         )
+
+    @property
+    def dtype(self):
+        return self._index.dtype
 
 
 class MMapIndexedDatasetBuilder(object):
@@ -556,8 +600,12 @@ class MMapIndexedDatasetBuilder(object):
         index = MMapIndexedDataset.Index(index_file_path(another_file))
         assert index.dtype == self._dtype
 
-        for size in index.sizes:
-            self._sizes.append(size)
+        total_len = len(index.sizes)+len(self._sizes)
+        print(f"    concat {another_file} size={len(index.sizes)} for a total size of {total_len}")
+
+        offset = len(self._sizes)
+        self._sizes.extend(index.sizes)
+        self._doc_idx.extend( (offset + index.doc_idx)[1:] )
 
         # Concatenate data
         with open(data_file_path(another_file), 'rb') as f:

--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -183,7 +183,7 @@ class BertModel(MegatronModule):
         )
 
         if self.post_process and self.add_binary_head:
-            lm_output, pooled_output = lm_output
+            lm_output, pooled_output = lm_output[0], lm_output[1]
         else:
             pooled_output = None
 

--- a/megatron/model/classification.py
+++ b/megatron/model/classification.py
@@ -79,7 +79,7 @@ class Classification(MegatronModule):
         )
 
         if self.post_process:
-            _, pooled_output = lm_output
+            _, pooled_output = lm_output[0], lm_output[1]
             classification_output = self.classification_dropout(pooled_output)
             classification_logits = self.classification_head(classification_output)
 

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -47,7 +47,7 @@ def get_language_model(num_tokentypes, add_pooler,
                        encoder_attn_mask_type, init_method=None,
                        scaled_init_method=None, add_decoder=False,
                        decoder_attn_mask_type=AttnMaskType.causal,
-                       pre_process=True, post_process=True, num_experts=1):
+                       pre_process=True, post_process=True, num_experts=[1]):
     """Build language model and return along with the key to save."""
     args = get_args()
 
@@ -312,7 +312,7 @@ class TransformerLanguageModel(MegatronModule):
                  add_pooler=False,
                  pre_process=True,
                  post_process=True,
-                 num_experts=1):
+                 num_experts=[1]):
         super(TransformerLanguageModel, self).__init__()
         args = get_args()
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -662,12 +662,12 @@ class ParallelTransformer(MegatronModule):
             # Each stage gets a contiguous set of layers.
             offset = mpu.get_pipeline_model_parallel_rank() * self.num_layers
             
-        assert len(num_experts) == 1 or len(num_experts) == self.num_layers // args.expert_interval, \
+        assert len(num_experts) == 1 or len(num_experts) == args.num_layers // args.expert_interval, \
         'num_experts must be either a single value or a list of the same length as the number of MoE layers'
 
         # Create the list of MoE experts
         if len(num_experts) == 1:
-            num_experts = num_experts * (self.num_layers // args.expert_interval)
+            num_experts = num_experts * (args.num_layers // args.expert_interval)
 
         self.layers = []
         # Build the layers

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -152,9 +152,9 @@ def pretrain(train_valid_test_dataset_provider,
     timers('train/valid/test-data-iterators-setup').stop()
     print_datetime('after dataloaders are built')
 
-    teacher_model = None
+    args.teacher_model = None
     if args.mos or args.kd: # Set up teacher model
-        teacher_model = setup_teacher_model(args, model_provider)
+        args.teacher_model = setup_teacher_model(args, model_provider)
 
     # Print setup timing.
     print_rank_0('done with setup ...')
@@ -165,8 +165,7 @@ def pretrain(train_valid_test_dataset_provider,
     if args.do_train and args.train_iters > 0:
         iteration = train(forward_step_func,
                           model, optimizer, lr_scheduler,
-                          train_data_iterator, valid_data_iterator, 
-                          teacher_model=teacher_model)
+                          train_data_iterator, valid_data_iterator)
     print_datetime('after training is done')
 
     if args.do_valid:
@@ -193,7 +192,7 @@ def pretrain(train_valid_test_dataset_provider,
         prefix = 'the end of training for test data'
         evaluate_and_print_results(prefix, forward_step_func,
                                    test_data_iterator, model,
-                                   0, True)
+                                   0, True, test=True)
 
 def update_train_iters(args):
 
@@ -508,7 +507,7 @@ def setup_model_and_optimizer(model_provider_func, teacher=False):
 
 
 def train_step(forward_step_func, data_iterator,
-               model, optimizer, lr_scheduler, teacher_model=None):
+               model, optimizer, lr_scheduler):
     """Single training step."""
     args = get_args()
     timers = get_timers()
@@ -539,9 +538,13 @@ def train_step(forward_step_func, data_iterator,
             forward_backward_func = forward_backward_pipelining_without_interleaving
     else:
         forward_backward_func = forward_backward_no_pipelining
+    if args.mos or args.kd:
+        args.teacher_forward = True
     losses_reduced = forward_backward_func(
         forward_step_func, data_iterator, model,
-        optimizer, timers, forward_only=False, teacher_model=teacher_model)
+        optimizer, timers, forward_only=False)
+    if args.mos or args.kd:
+        args.teacher_forward = False
 
     # All-reduce if needed.
     if not args.deepspeed and args.DDP_impl == 'local':
@@ -897,7 +900,7 @@ def save_checkpoint_and_time(iteration, model, optimizer, lr_scheduler):
 
 
 def train(forward_step_func, model, optimizer, lr_scheduler,
-          train_data_iterator, valid_data_iterator, teacher_model=None):
+          train_data_iterator, valid_data_iterator):
     """Train the model function."""
     args = get_args()
     timers = get_timers()
@@ -936,18 +939,20 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
                        train_data_iterator,
                        model,
                        optimizer,
-                       lr_scheduler,
-                       teacher_model=teacher_model)
+                       lr_scheduler)
         iteration += 1
         args.iteration = iteration
         new_samples = mpu.get_data_parallel_world_size() * \
                                        args.micro_batch_size * \
                                        get_num_microbatches()
         args.consumed_train_samples += new_samples
-        if args.curriculum_learning:
-            args.consumed_train_tokens += new_samples * args.curriculum_seqlen
-        else:
-            args.consumed_train_tokens += new_samples * args.seq_length
+        if not args.custom_token_counting:
+            # Models like BERT have padding thus need special token counting.
+            # See example in ../../pretrain_bert.py.
+            if args.curriculum_learning:
+                args.consumed_train_tokens += new_samples * args.curriculum_seqlen
+            else:
+                args.consumed_train_tokens += new_samples * args.seq_length
 
         # Logging.
         if args.deepspeed:
@@ -1089,7 +1094,7 @@ def evaluate(forward_step_func, data_iterator, model, verbose=False):
 
 def evaluate_and_print_results(prefix, forward_step_func,
                                data_iterator, model,
-                               iteration, verbose=False):
+                               iteration, verbose=False, test=False):
     """Helper function to evaluate and dump results on screen."""
     args = get_args()
     writer = get_tensorboard_writer()
@@ -1101,21 +1106,22 @@ def evaluate_and_print_results(prefix, forward_step_func,
         ppl = math.exp(min(20, total_loss_dict[key].item()))
         string += '{} PPL: {:.6E} | '.format(key, ppl)
         if writer and is_last_rank():
-            writer.add_scalar(f'lm-loss-validation/{key} validation',
+            data_type = 'test' if test else 'validation'
+            writer.add_scalar(f'lm-loss-validation/{key} {data_type}',
                               total_loss_dict[key].item(),
                               iteration)
-            writer.add_scalar(f'lm-loss-validation/{key} validation vs samples',
+            writer.add_scalar(f'lm-loss-validation/{key} {data_type} vs samples',
                               total_loss_dict[key].item(),
                               args.consumed_train_samples)
-            writer.add_scalar(f'lm-loss-validation/{key} validation vs tokens',
+            writer.add_scalar(f'lm-loss-validation/{key} {data_type} vs tokens',
                               total_loss_dict[key].item(),
                               args.consumed_train_tokens)
             if args.log_validation_ppl_to_tensorboard:
-                writer.add_scalar(f'lm-loss-validation/{key} validation ppl', ppl,
+                writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl', ppl,
                                   iteration)
-                writer.add_scalar(f'lm-loss-validation/{key} validation ppl vs samples',
+                writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs samples',
                                   ppl, args.consumed_train_samples)
-                writer.add_scalar(f'lm-loss-validation/{key} validation ppl vs tokens',
+                writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs tokens',
                                   ppl, args.consumed_train_tokens)
 
     length = len(string) + 1

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -202,7 +202,7 @@ def calculate_mos_loss(args, stu_output, teacher_model, tokens, position_ids, at
         mos_loss = mos_loss.div(args.seq_length) * beta
     return mos_loss
 
-def forward_step(data_iterator, model, teacher_model=None):
+def forward_step(data_iterator, model):
     """Forward step."""
     args = get_args()
     timers = get_timers()
@@ -235,7 +235,9 @@ def forward_step(data_iterator, model, teacher_model=None):
     mos_loss = 0
     if args.mos or args.kd:
         assert model.training
-        mos_loss = calculate_mos_loss(args, stu_output, teacher_model, tokens, position_ids, attention_mask)
+        if args.teacher_forward and args.teacher_model is not None:
+            mos_loss = calculate_mos_loss(args, stu_output,
+                args.teacher_model[0], tokens, position_ids, attention_mask)
     
     # Output_tensor stores the standard loss, loos_func calculates the total loss.
     return output_tensor, partial(loss_func, loss_mask, moe_loss, mos_loss)


### PR DESCRIPTION
Adding examples of BERT-style models pre-training/fine-tuning with DeepSpeed integration (e.g., ZeRO + tensor-slicing model parallelism), and how to use the example with the public Pile data (https://github.com/EleutherAI/the-pile) and reference throughput/accuracy numbers. Including API refactoring/fixes to enable the BERT case.