### PR TITLE
fix throughput_calculator

### DIFF
--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -217,7 +217,7 @@ def throughput_calculator(model, args, iteration_time, total_iterations):
     batch_size = args.micro_batch_size * get_num_microbatches() * args.data_parallel_size
     samples_per_model = batch_size * args.seq_length
     model_replica_count = torch.distributed.get_world_size() / gpus_per_model
-    approx_parameters_in_billions = get_parameters_in_billions(model)
+    approx_parameters_in_billions = None if (model is None) else get_parameters_in_billions(model)
     elapsed_time_per_iter = iteration_time/total_iterations
     samples_per_second = batch_size / elapsed_time_per_iter
 


### PR DESCRIPTION
Fix a corner case for throughput_calculator, where the model argument could be None since training_log() has model=None default https://github.com/microsoft/Megatron-DeepSpeed/blob/5431d337c13e04a80cd47d227a0e98699cf67965/megatron/training.py#L634 and tasks like Glue fine-tuning will trigger the None default.