### PR TITLE
Fix a bug for gpt pre-training. 

### DIFF
--- a/megatron/mpu/random.py
+++ b/megatron/mpu/random.py
@@ -308,6 +308,8 @@ class CheckpointFunction(torch.autograd.Function):
 
         if isinstance(outputs, torch.Tensor):
             outputs = (outputs,)
+        else:
+            outputs = outputs[0:-1]
         torch.autograd.backward(outputs, args)
         grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else inp
                       for inp in detached_inputs)

--- a/megatron/mpu/random.py
+++ b/megatron/mpu/random.py
@@ -308,8 +308,10 @@ class CheckpointFunction(torch.autograd.Function):
 
         if isinstance(outputs, torch.Tensor):
             outputs = (outputs,)
-        else:
-            outputs = outputs[0:-1]
+        elif len(outputs) == 2 and isinstance(outputs[1], torch.Tensor) and \
+                torch.equal(outputs[1], torch.tensor(0).cuda()):
+            # a hacky solution to overcome issue when running old script examples/pretrain_gpt_distributed.sh
+            outputs = (outputs[0],)
         torch.autograd.backward(outputs, args)
         grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else inp
                       for inp in detached_inputs)


### PR DESCRIPTION
For GPT pre-training with `examples/pretrain_gpt_distributed.sh` commands. It will encounter an error like this.
<img width="500" alt="c727e6e174c6794195549064b27e9046" src="https://user-images.githubusercontent.com/25279174/191633188-bc197928-f6ff-4f68-8d03-b14fe8ec9608.png">

It seems that the tuple `outputs` here (https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/mpu/random.py#L311) contains a redundant torch tensor at the end of the tuple, which will cause the error above.
<img width="500" alt="image" src="https://user-images.githubusercontent.com/25279174/191633738-ff54ef76-0359-4c0d-935d-fb38b8cbd8d1.png">

By removing the last value of the `outputs`, the pre-train can be run through. 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/25279174/191633941-f84a45da-6a33-4c21-a098-fb30016df236.png">

**This PR is a straight forward solution for the problem. If there is a better way, please let me know.**

