### PR TITLE
Modifying loss checking to support bf16.

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -963,7 +963,10 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
 
         # Logging.
         if args.deepspeed:
-            loss_scale = model[0].optimizer.cur_scale
+            if hasattr(model[0].optimizer, 'cur_scale'):
+                loss_scale = model[0].optimizer.cur_scale
+            else:
+                loss_scale = None
         else:
             loss_scale = optimizer.get_loss_scale().item()
         params_norm = None


### PR DESCRIPTION
Checking for the `cur_scale` attribute on the optimizer allows for use of the BF16 optimizer with Megatron.