### PR TITLE
Get text-gen w/o DS working as a baseline

### DIFF
--- a/examples/generate_text.sh
+++ b/examples/generate_text.sh
@@ -5,7 +5,8 @@ VOCAB_FILE=gpt2-vocab.json
 MERGE_FILE=gpt2-merges.txt
 b=8
 mp=1
-experts=2
+#experts=2
+experts=1
 nodes=1
 gpus=1
 
@@ -14,12 +15,12 @@ use_tutel=""
 #use_tutel="--use-tutel"
 
 
-#ds_inference=""
-ds_inference="--ds-inference"
+ds_inference=""
+#ds_inference="--ds-inference"
 
 launch_cmd="deepspeed --num_nodes $nodes --num_gpus $gpus"
 L=24
-H=2048
+H=1024
 A=16
 #experts1=${experts[$k]}
 program_cmd="tools/generate_samples_gpt.py \
@@ -33,16 +34,18 @@ program_cmd="tools/generate_samples_gpt.py \
        --num-experts ${experts} \
        --mlp-type standard \
        --micro-batch-size $b \
-       --seq-length 10 \
-       --out-seq-length 10 \
+       --seq-length 1024 \
+       --out-seq-length 1024 \
        --temperature 1.0 \
        --vocab-file $VOCAB_FILE \
        --merge-file $MERGE_FILE \
        --genfile unconditional_samples.json \
        --top_p 0.9 \
        --log-interval 1 \
-       --num-samples $((100*$b))
+       --num-samples 0 \
+       --load $CHECKPOINT_PATH \
        $use_tutel $ds_inference"
+       #--num-samples $((100*$b)) \
 
 echo $launch_cmd $program_cmd
 $launch_cmd $program_cmd

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -137,7 +137,7 @@ def save_checkpoint(iteration, model, optimizer, lr_scheduler):
                 for i in range(len(model)):
                     mpu.set_virtual_pipeline_model_parallel_rank(i)
                     state_dict['model%d' % i] = model[i].state_dict_for_save_checkpoint()
-            
+
             # Optimizer stuff.
             if not args.no_save_optim:
                 if optimizer is not None:
@@ -169,7 +169,7 @@ def save_checkpoint(iteration, model, optimizer, lr_scheduler):
 
         # Saving is a collective communication
         checkpoint_name = get_checkpoint_name(args.save, iteration)
-        
+
         # Trim off the filename and mp_rank_* directory.
         for _ in range(3):
             checkpoint_name = os.path.dirname(checkpoint_name)
@@ -201,7 +201,8 @@ def _transpose_first_dim(t, num_splits, num_splits_first, model):
     # specific to self attention so should work for cross attention as well
     while hasattr(model, 'module'):
         model = model.module
-    attention_module = model.language_model.encoder.layers[0].self_attention
+    #attention_module = model.language_model.encoder.layers[0].self_attention
+    attention_module = model.language_model.encoder.layers[0].attention
     hidden_size_per_attention_head = attention_module.hidden_size_per_attention_head
     num_attention_heads_per_partition = attention_module.num_attention_heads_per_partition
     if num_splits_first:
@@ -442,7 +443,7 @@ def load_checkpoint(model, optimizer, lr_scheduler, load_arg='load', strict=True
 def load_biencoder_checkpoint(model, only_query_model=False,
         only_context_model=False, custom_load_path=None):
     """
-    selectively load retrieval models for indexing/retrieving 
+    selectively load retrieval models for indexing/retrieving
     from saved checkpoints
     """
 

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -191,7 +191,7 @@ def generate_samples_input_from_file(model):
             context_count += 1
 
 # We added this function to support the tasks evaluation such as squad
-# and drop in the https://github.com/EleutherAI/lm-evaluation-harness 
+# and drop in the https://github.com/EleutherAI/lm-evaluation-harness
 # codebase. The lm-evaluation-harness code can now call this function
 # similar to their current generate function call used for gpt style models.
 def generate_samples_eval(model, context, max_gen_length, eos_token_id):
@@ -218,7 +218,7 @@ def generate_samples_eval(model, context, max_gen_length, eos_token_id):
     decode_tokens = decode_tokens[0].cpu().numpy().tolist()
     trim_decode_tokens = tokenizer.detokenize(
         decode_tokens)[raw_text_len:]
- 
+
     return trim_decode_tokens
 
 
@@ -416,9 +416,9 @@ def get_token_stream(model, context_tokens, model_latencies=[], single_token_lat
     batch_token_iterator = sample_sequence_batch(model, context_tokens_tensor,
                                                  context_length_tensor,
                                                  attention_mask, position_ids, model_latencies=model_latencies)
-    
+
     count = 0
-    
+
     t0=time.time()
     for tokens, lengths in batch_token_iterator:
         if count > 1:
@@ -559,9 +559,9 @@ def sample_sequence_batch(model, context_tokens, context_lengths,
                     logits /= args.temperature
                     logits = top_k_logits(logits, top_k=args.top_k,
                                           top_p=args.top_p)
-                    log_probs = torch.ones_like(logits) 
+                    #log_probs = torch.ones_like(logits)
                     #TODO: Fix this
-                    #log_probs = F.softmax(logits, dim=-1)
+                    log_probs = F.softmax(logits, dim=-1)
                     prev = torch.multinomial(log_probs, num_samples=1).view(-1)
 
                 started = context_lengths <= context_length

--- a/tools/generate_samples_gpt.py
+++ b/tools/generate_samples_gpt.py
@@ -41,7 +41,7 @@ def model_provider(pre_process=True, post_process=True):
 
     print_rank_0('building GPT model ...')
     model = GPTModel(num_tokentypes=0, parallel_output=False,
-                     pre_process=pre_process, post_process=post_process, 
+                     pre_process=pre_process, post_process=post_process,
                      return_moe_loss=False) # we need to set "return_moe_loss" for the inference_mode
     return model
 
@@ -102,7 +102,7 @@ def print_latency(latency_set, title=""):
         print("\tP95 Latency: {0:8.2f} ms".format(p95 * 1000))
         print("\tP99 Latency: {0:8.2f} ms".format(p99 * 1000))
         print("\t999 Latency: {0:8.2f} ms".format(p999 * 1000))
-        
+
 def main():
     """Main program."""
     latencies = []
@@ -115,7 +115,7 @@ def main():
                                        'no_load_optim': True})
 
     args = get_args()
-    
+
     if args.num_layers_per_virtual_pipeline_stage is not None:
         print("Interleaved pipeline schedule is not yet supported for text generation.")
         exit()
@@ -142,8 +142,8 @@ def main():
             generate_samples_interactive(model)
     else:
         generate_and_write_samples_unconditional(model, latencies, single_token_latency, model_latencies)
-    
-    
+
+
     #if torch.cuda.current_device() == 0:
     if torch.distributed.get_rank() == 0:
         print_latency(latencies)
@@ -154,13 +154,13 @@ def main():
 def ds_inference(model, args):
     import megatron.model as mm
     engine = deepspeed.init_inference(model=model,
-                                      mp_size=args.tensor_model_parallel_size, 
-                                      mpu=mpu,
+                                      mp_size=args.tensor_model_parallel_size,
+                                      tensor_parallel={"mpu": mpu},
                                       dtype=torch.half,
                                       replace_with_kernel_inject=True,
                                       moe_experts=args.num_experts,
                                       moe_type=args.mlp_type)
-    
+
     return engine.module
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR gets text-generation working in the `examples/generate_text.sh` example working w/o DS inference enabled as a baseline. The `sample_sequence_batch` function has been updated to perform the softmax when calculating `log_probs`, instead of setting it to 1's using `torch.ones_like(...)`. Extra whitespace is also removed.

Currently, the `examples/generate_text.sh` example produces the same nonsensical output irrespective of input context or whether DS inference is enabled or not:
<pre>
Oz jewelry Hod BombCook hiber csivalry Consumptionysics discipline wholesale aversionwic authoritativeduct...
</pre>
This PR gets the example working w/o DS inference, e.g.:
<pre>
Context: Hiking in nature is a

Megatron-LM:  great way to immerse yourself in nature and to get some exercise...
</pre>

**TODO:** DS inference is still giving incorrect output, although the output varies depending on the context:
<pre>
Context: Hiking in nature is a

Megatron-LM:  Over Central Por Over Iz Iz Our Iz Iz Amb Our IB
</pre>