### PR TITLE
Fix deprecated numpy types

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -98,8 +98,8 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
-    7: np.double,
+    6: np.float32,
+    7: np.float64,
     8: np.uint16
 }
 
@@ -271,8 +271,8 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
-        np.double: 8
+        np.float32: 4,
+        np.float64: 8
     }
 
     def __init__(self, out_file, dtype=np.int32):


### PR DESCRIPTION
Numpy has had `np.float` deprecated for many versions. This fix will allow us to run with more recent version of the library:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations