### PR TITLE
fix integer overflow in the cpp implementation of build_sample_idx

### DIFF
--- a/megatron/data/helpers.cpp
+++ b/megatron/data/helpers.cpp
@@ -118,7 +118,7 @@ py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
 
     // Mapping and it's length (1D).
     int64_t num_samples = (num_epochs * tokens_per_epoch - 1) / seq_length;
-    int32_t* sample_idx = new int32_t[2*(num_samples+1)];
+    int64_t* sample_idx = new int64_t[2*(num_samples+1)];
 
     cout << "    using:" << endl << std::flush;
     cout << "     number of documents:       " <<
@@ -135,7 +135,7 @@ py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
     // Index into doc_idx.
     int64_t doc_idx_index = 0;
     // Begining offset for each document.
-    int32_t doc_offset = 0;
+    int64_t doc_offset = 0;
     // Start with first document and no offset.
     sample_idx[2 * sample_index] = doc_idx_index;
     sample_idx[2 * sample_index + 1] = doc_offset;
@@ -143,11 +143,11 @@ py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
 
     while (sample_index <= num_samples) {
         // Start with a fresh sequence.
-      int32_t remaining_seq_length = seq_length + 1;
+      int64_t remaining_seq_length = seq_length + 1;
       while (remaining_seq_length != 0) {
             // Get the document length.
-	auto doc_id = doc_idx[doc_idx_index];
-	auto doc_length = sizes[doc_id] - doc_offset;
+	auto doc_id = static_cast<int64_t>(doc_idx[doc_idx_index]);
+	auto doc_length = static_cast<int64_t>(sizes[doc_id]) - doc_offset;
 	// And add it to the current sequence.
 	remaining_seq_length -= doc_length;
 	// If we have more than a full sequence, adjust offset and set
@@ -176,7 +176,7 @@ py::array build_sample_idx(const py::array_t<int32_t>& sizes_,
       });
 
     // Return the numpy array.
-    const auto byte_size = sizeof(int32_t);
+    const auto byte_size = sizeof(int64_t);
     return py::array(std::vector<int64_t>{num_samples+1, 2}, // shape
                      {2*byte_size, byte_size}, // C-style contiguous strides
                      sample_idx, // the data pointer


### PR DESCRIPTION
use int64_t instead of int32_t to avoid integer overflow.

Signed-off-by: yulu.jia <yulu.jia@bytedance.com>