### PR TITLE
Always process moe_loss from layer output in ParallelTransformer.forward

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -785,9 +785,8 @@ class ParallelTransformer(MegatronModule):
                                       enc_dec_attn_mask=enc_dec_attn_mask,
                                       layer_past=past,
                                       get_key_value=get_key_value)
-                if not self.ds_inference:
-                    hidden_states, moe_loss = hidden_states
-                    moe_losses.append(moe_loss)
+                hidden_states, moe_loss = hidden_states
+                moe_losses.append(moe_loss)
                 if get_key_value:
                     hidden_states, present = hidden_states
                     presents.append(present)


### PR DESCRIPTION
This PR fix a bug what fails `examples/generate_text.sh` when manually turn off kernel injection.

In `ParallelTransformer.forward()`, `moe_loss` is conditionally removed from `hidden_states` when process output of each `ParallelTransformerLayer.forward()`.  As the following code shows.  https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/model/transformer.py#L788

But from `ParallelTransformerLayer.forward()`, `moe_loss` is unconditionally returned with `hidden_states`, as a tuple of `(hidden_states, moe_loss)` https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/model/transformer.py#L565

This miss match cause hidden state tensor cannot be get from output of each layer.  Instead, `hidden_states` would remain as a list and passed to next layer, which causing problem.

Reproduce of this bug:
1. Turn off `replace_with_kernel_inject` at this line: https://github.com/microsoft/Megatron-DeepSpeed/blob/main/tools/generate_samples_gpt.py#L160
2. Run examples/generate_text.sh
`echo Hiking in nature is |examples/generate_text.sh`
Will get the following error:
`TypeError: layer_norm(): argument 'input' (position 1) must be Tensor, not list     `

This PR fix this bug by move the moe_loss extraction code out of the condition, which makes it always match the behavior of ParallelTransformerLayer