### PR TITLE
fix(utils.py): add () after device_name

### DIFF
--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -21,7 +21,7 @@ import torch
 from torch.nn.parallel import DistributedDataParallel as torchDDP
 
 from deepspeed.accelerator import get_accelerator
-if get_accelerator().device_name == 'cuda':
+if get_accelerator().device_name() == 'cuda':
     from apex.multi_tensor_apply import multi_tensor_applier
     import amp_C
 
@@ -67,7 +67,7 @@ def calc_params_l2_norm(model):
     # Calculate norm
     dummy_overflow_buf = get_accelerator().IntTensor([0])
     
-    if get_accelerator().device_name == 'cuda':
+    if get_accelerator().device_name() == 'cuda':
 
         norm, _ = multi_tensor_applier(
             amp_C.multi_tensor_l2norm,


### PR DESCRIPTION
in `megatron/utils.py` line 24 and line 70,  `()` is missed after `get_accelerator().device_name`, which will cause the condition to be always false. I think the `()` should be added here.