### PR TITLE
Fixed a bug when run on bf16+pipeline parallelism

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -941,7 +941,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                 if avg > 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 total_loss_dict[key] = get_accelerator().FloatTensor([0.0])
-        log_string += ' loss scale: {:.1f} |'.format(loss_scale)
+        if loss_scale is not None:
+	    log_string += ' loss scale: {:.1f} |'.format(loss_scale)
         if grad_norm is not None:
             log_string += ' grad norm: {:.3f} |'.format(grad_norm)
         if num_zeros_in_grad is not None:


### PR DESCRIPTION
Hi, when run the GPT model for bf16+pipeline parallelism, using BF16_optimizer from deepspeed, we got the error message(TypeError: unsupported format string passed to NoneType.__format__) for loss_scale.
can observe in code(https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/training.py#L1065):
if args.deepspeed:
    if hasattr(model[0].optimizer, 'cur_scale'):
        loss_scale = model[0].optimizer.cur_scale
    else:
        loss_scale = None
the loss_scale value is None, because the BF16_optimizer has no attr of 'cur_scale', this pr is to add a judgement before loss_scale to fix this error.