### PR TITLE
Fix the tab error for loss_scale

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -941,7 +941,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                 if avg > 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 total_loss_dict[key] = get_accelerator().FloatTensor([0.0])
-        log_string += ' loss scale: {:.1f} |'.format(loss_scale)
+        if loss_scale is not None:
+	    log_string += ' loss scale: {:.1f} |'.format(loss_scale)
         if grad_norm is not None:
             log_string += ' grad norm: {:.3f} |'.format(grad_norm)
         if num_zeros_in_grad is not None:

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -942,7 +942,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 total_loss_dict[key] = get_accelerator().FloatTensor([0.0])
         if loss_scale is not None:
-	    log_string += ' loss scale: {:.1f} |'.format(loss_scale)
+            log_string += ' loss scale: {:.1f} |'.format(loss_scale)
         if grad_norm is not None:
             log_string += ' grad norm: {:.3f} |'.format(grad_norm)
         if num_zeros_in_grad is not None:


### PR DESCRIPTION
come from this pr issue: https://github.com/microsoft/Megatron-DeepSpeed/pull/134,
sorry for miss a space before the pr of [fix a bug when run on bf16+pp], this pr is to add a space before https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/training.py#L945 to fix the tab error.