### PR TITLE
fix(training.py): logical bug in eval_iters_calculation

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -488,7 +488,7 @@ def setup_model_and_optimizer(model_provider_func, teacher=False,
                 # Number of train/valid/test samples.
                 if args.train_samples:
                     train_samples = args.train_samples
-                    args.train_iters = train_samples // args.global_batch_size
+                    update_train_iters(args)
                 else:
                     train_samples = args.train_iters * args.global_batch_size
                 # eval_iters and test_iters here are not actually used, only for
@@ -1273,7 +1273,7 @@ def build_train_valid_test_data_iterators(
         # Number of train/valid/test samples.
         if args.train_samples:
             train_samples = args.train_samples
-            args.train_iters = train_samples // args.global_batch_size
+            update_train_iters(args)
         else:
             train_samples = args.train_iters * args.global_batch_size
         eval_iters = (args.train_iters // args.eval_interval + 1) * \

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -488,6 +488,7 @@ def setup_model_and_optimizer(model_provider_func, teacher=False,
                 # Number of train/valid/test samples.
                 if args.train_samples:
                     train_samples = args.train_samples
+                    args.train_iters = train_samples // args.global_batch_size
                 else:
                     train_samples = args.train_iters * args.global_batch_size
                 # eval_iters and test_iters here are not actually used, only for
@@ -1272,6 +1273,7 @@ def build_train_valid_test_data_iterators(
         # Number of train/valid/test samples.
         if args.train_samples:
             train_samples = args.train_samples
+            args.train_iters = train_samples // args.global_batch_size
         else:
             train_samples = args.train_iters * args.global_batch_size
         eval_iters = (args.train_iters // args.eval_interval + 1) * \


### PR DESCRIPTION
From `arguments.py`, we agree that train_samples and train_iters are two conflicting ways to specify when to stop training. 
```python
if args.train_samples:
        # If we use sample-based training, make sure the
        # iteration-based options are off.
        assert args.train_iters is None, \
            'expected sample-based training'
```

Then pay attention to functions `build_train_valid_test_data_iterators` and `setup_model_and_optimizer`  in `training.py`, the logic before this PR is wrong. If train_samples is not None, (i.e. go into the if branch), then train_iters must be None, causing "None type has no attributes xxx" error when trying to calculate `eval_iters`

Then why before this PR fix we seldom notice this bug? This is because there is another function called `update_train_iters` in `training.py`. This method will calculate iters when samples is not None, and calculate samples if iters is not None. It sounds good, but in some parameter situation, this method is not called since some branch is False. 

