### PR TITLE
passing num_experts to BERT and T5 language models

### DIFF
--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -150,7 +150,9 @@ class BertModel(MegatronModule):
             init_method=init_method,
             scaled_init_method=scaled_init_method,
             pre_process=self.pre_process,
-            post_process=self.post_process)
+            post_process=self.post_process,
+            num_experts=args.num_experts,
+        )
 
         self.initialize_word_embeddings(init_method_normal)
         if self.post_process:

--- a/megatron/model/t5_model.py
+++ b/megatron/model/t5_model.py
@@ -102,7 +102,9 @@ class T5Model(MegatronModule):
             add_decoder=True,
             encoder_attn_mask_type=AttnMaskType.padding,
             init_method=init_method,
-            scaled_init_method=scaled_init_method)
+            scaled_init_method=scaled_init_method,
+            num_experts=args.num_experts,
+        )
 
         self.lm_head = T5LMHead(
             self.language_model.embedding.word_embeddings.weight.size(0),


### PR DESCRIPTION
Unlike `gpt_model` [here](https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/model/gpt_model.py#L90) `bert_model` and `t5_model` do not pass `args.num_experts` when constructing a `language_model` hence the default value of `[1]` is used meaning MoE layers are never created.