### PR TITLE
fixing BERT lm_output extraction without post process or binary head

### DIFF
--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -187,7 +187,7 @@ class BertModel(MegatronModule):
         if self.post_process and self.add_binary_head:
             lm_output, pooled_output = lm_output[0], lm_output[1]
         else:
-            pooled_output = None
+            lm_output, pooled_output = lm_output[0], None
 
         if self.post_process:
             return post_language_model_processing(lm_output, pooled_output,


### PR DESCRIPTION
Without this using `post_process=True` and `add_binary_head=False` crashes with:

```
File "/opt/conda/envs/pytorch/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/envs/pytorch/lib/python3.9/site-packages/torch/nn/modules/linear.py", line 114, in forward
    return F.linear(input, self.weight, self.bias)
TypeError: linear(): argument 'input' (position 1) must be Tensor, not tuple
```

That's because `(encoder_output, *moe_losses)` is returned [here](https://github.com/microsoft/Megatron-DeepSpeed/blob/7491937ef43f96d167a7e0b91c1e3be8d5397d17/megatron/model/language_model.py#L409).