### PR TITLE
skipping activation function assertion while FLOPS profiler measures throughput

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -141,7 +141,8 @@ class ParallelMLP(MegatronModule):
 
         if self.bias_gelu_fusion:
             assert self.add_bias is True
-            assert self.activation_func == F.gelu
+            # DeepSpeed FLOPS profiler temporarily substitues functions like F.gelu to calculate the throughput
+            assert hasattr(self, "__flops__") or self.activation_func == F.gelu
             intermediate_parallel = bias_gelu_impl(intermediate_parallel, bias_parallel)
         else:
             if bias_parallel is not None:


### PR DESCRIPTION
DeepSpeed's FLOPS profiler replaces functions like `F.gelu` with bogus activation functions to measure the throughput [here](https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/profiling/flops_profiler/profiler.py#L809).
Skipping the assertion for forward passes while it's the case.