### PR TITLE
fix error comment in megatron/training.py

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -40,7 +40,7 @@ from megatron.data.data_samplers import build_pretraining_data_loader
 from megatron.utils import calc_params_l2_norm
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.utils import report_memory, throughput_calculator, checkpoint_throughput_calculator
-# from megatron.model.vision.knn_monitor import compute_feature_bank
+from megatron.model.vision.knn_monitor import compute_feature_bank
 from megatron.arguments import core_transformer_config_from_args
 
 import deepspeed


### PR DESCRIPTION
This PR is to fix error comment in megatron/training.py caused by https://github.com/microsoft/Megatron-DeepSpeed/pull/162. Sorry about this error.