### PR TITLE
removing obsolete comment about MoE divergence with MP > 1

### DIFF
--- a/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_MoE128.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_MoE128.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=8
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_PR-MoE64or128.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_PR-MoE64or128.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=8
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_PR-MoE64or128_MoS.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_PR-MoE64or128_MoS.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_dense.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_1.3B_dense.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=260000000000
 BATCH_SIZE=2
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=4
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_125M_MoE64.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_125M_MoE64.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_350M_MoE128.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_350M_MoE128.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_350M_PR-MoE32or64.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_350M_PR-MoE32or64.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_350M_PR-MoE32or64_MoS.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_350M_PR-MoE32or64_MoS.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=300000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_350M_dense.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_350M_dense.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=260000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_6.7B_dense.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_6.7B_dense.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=260000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=8
 
 ## Pipeline parallelism

--- a/examples_deepspeed/compression/ds_pretrain_gpt_350M_dense_kd.sh
+++ b/examples_deepspeed/compression/ds_pretrain_gpt_350M_dense_kd.sh
@@ -113,7 +113,6 @@ LR_DECAY_TOKENS=260000000000
 BATCH_SIZE=4
 
 ## Model parallelism, 1 is no MP
-## Currently MoE models have divergence issue when MP > 1.
 MP_SIZE=1
 
 ## Pipeline parallelism


### PR DESCRIPTION
As per discussion in https://github.com/microsoft/Megatron-DeepSpeed/issues/151#issuecomment-1644378234 with @conglongli all future divergence issues are to be treated as bug reports.