### PR TITLE
fixing language_model forward return values

### DIFF
--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -183,7 +183,7 @@ class BertModel(MegatronModule):
         )
 
         if self.post_process and self.add_binary_head:
-            lm_output, pooled_output = lm_output
+            lm_output, pooled_output, _ = lm_output
 
             # Return pooled output (e.g., when computing Bert embeddings).
             if self.return_embeddings:
@@ -206,12 +206,14 @@ class BertModel(MegatronModule):
             pooled_output = None
 
         if self.post_process:
+            lm_output = lm_output if self.add_binary_head else lm_output[0]
             return post_language_model_processing(lm_output, pooled_output,
                                                   self.lm_head, self.binary_head,
                                                   lm_labels,
                                                   self.shared_embedding_or_output_weight(),
                                                   self.fp16_lm_cross_entropy)
-        return lm_output
+        else:
+            return lm_output
 
 
     def state_dict_for_save_checkpoint(self, prefix='', keep_vars=False):

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -112,7 +112,7 @@ class GPTModel(MegatronModule):
                 # If got a None input, need to reset curriculum_seqlen on user side
                 args.curriculum_seqlen = args.seq_length
 
-        lm_output, *moe_losses = self.language_model(
+        lm_output, moe_losses = self.language_model(
             input_ids,
             position_ids,
             attention_mask,
@@ -128,10 +128,7 @@ class GPTModel(MegatronModule):
                 self.parallel_output,
                 self.fp16_lm_cross_entropy)
 
-        if self.return_moe_loss:
-            return (lm_output, *moe_losses)
-        else:
-            return lm_output
+        return lm_output, moe_losses if self.return_moe_loss else lm_output
 
     def state_dict_for_save_checkpoint(self, prefix='', keep_vars=False):
 

--- a/megatron/model/t5_model.py
+++ b/megatron/model/t5_model.py
@@ -127,7 +127,7 @@ class T5Model(MegatronModule):
                                         enc_hidden_states=enc_hidden_states)
 
         if self.post_process and self.add_decoder:
-            decoder_output, encoder_output = lm_output
+            decoder_output, encoder_output, _, _ = lm_output
             # Output. [s, b, h]
             lm_logits = self.lm_head(decoder_output,
                                      self.shared_embedding_or_output_weight())
@@ -148,11 +148,9 @@ class T5Model(MegatronModule):
                 lm_loss = lm_loss.transpose(0,1).contiguous()
             return lm_loss
         elif self.add_decoder and not self.add_encoder:
-            decoder_output, encoder_output = lm_output
-            return decoder_output
-        else:
-            encoder_output = lm_output
-            return encoder_output
+            decoder_output, _, decoder_moe_losses, _= lm_output
+            return decoder_output, decoder_moe_losses
+        return lm_output
 
     def state_dict_for_save_checkpoint(self, prefix='', keep_vars=False):
         """For easy load when model is combined with other heads,

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -229,7 +229,7 @@ def calculate_mos_loss(args, stu_output, teacher_model, tokens, position_ids, at
                 position_ids = position_ids[:, :curriculum_seqlen].contiguous()
                 attention_mask = attention_mask[:, :, :curriculum_seqlen, :curriculum_seqlen].contiguous()
                 # No need to truncate labels as we do not need it for the teacher logits
-            tea_output, *tea_other_losses = teacher_model(tokens, position_ids, attention_mask)
+            tea_output, tea_other_losses = teacher_model(tokens, position_ids, attention_mask)
             assert stu_output.size() == tea_output.size(), 'teacher and student output should match in size. Student: {}, Teacher: {}, CL seq length {}'.format(stu_output.size(), tea_output.size(), args.curriculum_seqlen)
 
         student_logits = F.log_softmax(stu_output / kd_temp, dim=2)
@@ -259,13 +259,13 @@ def forward_step(data_iterator, model):
 
     if args.mos or args.kd:
         # The forward func can return either the loss or the logits, depending on whether passing in the labels or not.
-        stu_output, *other_losses = model(tokens, position_ids, attention_mask)
+        stu_output, other_losses = model(tokens, position_ids, attention_mask)
         if args.curriculum_learning_legacy and args.curriculum_seqlen < args.seq_length:
             assert args.curriculum_seqlen is not None
             labels = labels[:, :args.curriculum_seqlen].contiguous()
         output_tensor = tensor_parallel.vocab_parallel_cross_entropy(stu_output.contiguous().float(), labels)
     else:
-        output_tensor, *other_losses = model(tokens, position_ids, attention_mask,
+        output_tensor, other_losses = model(tokens, position_ids, attention_mask,
                                             labels=labels)
     if args.curriculum_learning_legacy and args.curriculum_seqlen < args.seq_length:
         loss_mask = loss_mask[:, :args.curriculum_seqlen].contiguous()


### PR DESCRIPTION
Fixing the following inconsistencies and bugs:
* `language_model.py`:
  * returning MoE losses, both from encoder and decoder
  * using lists to return MoE losses
* `t5_model.py`:
  * handling MoE losses, both from encoder and decoder
  * returning all logits/moe_losses for `post_process=False`, so that we an calculate the combined LM and MoE loss, e.g. [Switch Transformer style](https://github.com/huggingface/transformers/blob/main/src/transformers/models/switch_transformers/modeling_switch_transformers.py#L1674-L1709)
 *  `gpt_model.py`:
   * returning moe_losses as list
*  `bert_model.py`:
   * handling MoE losses for `post_process=True`
   * fixing `lm_output` handling for `add_binary_head=False`

Verified this works for both BERT and T5 with `post_process=False`.

Open questions:
1. When `language_model` only has decoder, should we omit returning `encoder_output` and `encoder_moe_losses`?