### PR TITLE
Fix the docs path to Azure ML Python SDK v1 setup

### DIFF
--- a/examples_deepspeed/azureml/README.md
+++ b/examples_deepspeed/azureml/README.md
@@ -4,7 +4,7 @@ Example script for running Megatron-DeepSpeed using Azure Machine Learning.
 ------
 
 # Workspace Setup
-Setup an AML workspace. Refer to: [set-up doc](https://github.com/Azure/azureml-examples/tree/main/python-sdk#set-up).
+Setup an AML workspace. Refer to: [set-up doc](https://github.com/Azure/azureml-examples/tree/main/v1/python-sdk#set-up).
 
 # Dataset Preparation
 Create AML Dataset. To run remote AML job, you need to provide AML FileDataset. 


### PR DESCRIPTION
Minor change. Link was broken. Changed it to the correct docs path.