### PR TITLE
Fix DeepSpeed MoE

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1114,6 +1114,8 @@ def _add_distributed_args(parser):
                        'a custom built image that support ring-exchange p2p.')
     group.add_argument('--local-rank', type=int, default=None,
                        help='local rank passed from distributed launcher.')
+    group.add_argument('--local_rank', type=int, default=None,
+                       help='local rank passed from distributed launcher.')
     group.add_argument('--lazy-mpu-init', type=bool, required=False,
                        help='If set to True, initialize_megatron() '
                        'skips DDP initialization and returns function to '

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -279,10 +279,17 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
         # https://github.com/pytorch/pytorch/blob/c47cf9bc7f9e02f649ab4ed53fe4d35732c92ab6/torch/_refs/__init__.py#L2761
         grad_output = grad_output.contiguous()
         # Convert the tensor shapes to 2D for execution compatibility
-        grad_output = grad_output.view(grad_output.shape[0] * grad_output.shape[1],
-                                       grad_output.shape[2])
-        total_input = total_input.view(total_input.shape[0] * total_input.shape[1],
-				       total_input.shape[2])
+        if len(grad_output.shape) == 3:
+            grad_output = grad_output.view(grad_output.shape[0] * grad_output.shape[1],
+                                        grad_output.shape[2])
+            total_input = total_input.view(total_input.shape[0] * total_input.shape[1],
+                        total_input.shape[2])
+        else:
+            # Somehow when DeepSpeed MoE is used, grad_output could have 4 dimensions.
+            # TODO: May need further investigation
+            total_input = total_input.contiguous()
+            grad_output = grad_output.view(-1, grad_output.shape[-1])
+            total_input = total_input.view(-1, total_input.shape[-1])
 
         if ctx.async_grad_allreduce:
             # Asynchronous all-reduce

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -432,6 +432,7 @@ class TransformerLanguageModel(MegatronModule):
                 self_attn_mask_type=self.encoder_attn_mask_type,
                 pre_process=self.pre_process,
                 post_process=self.post_process,
+                num_experts=self.num_experts
             )
             self._encoder_key = 'encoder'
         else:


### PR DESCRIPTION
Fix several issues about DeepSpeed MoE training after recent rebase:

1. Fix bug that num_experts not properly passed when initializing model (bug reported by https://github.com/microsoft/DeepSpeed/issues/4039)
2. Add back args.local_rank which is needed by DeepSpeed
3. Fix an issue in `megatron/core/tensor_parallel/layers.py` where when DeepSpeed MoE is used, the number of dimensions is different from expected (may need further investigation).

After the above fixes, confirmed that DeepSpeed MoE training work fine and the loss curve match the training with older Megatron-DeepSpeed.