### PR TITLE
Fix parameter initialization with ZeRO3

### DIFF
--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -61,7 +61,7 @@ class BertLMHead(MegatronModule):
         tensor_parallel.set_tensor_model_parallel_attributes(self.bias, True, 0, 1)
         self.parallel_output = parallel_output
 
-        self.dense = get_linear_layer(hidden_size, hidden_size, config.init_method)
+        self.dense = get_linear_layer(hidden_size, hidden_size, config.init_method, gather_params_on_init=args.zero_stage == 3)
         setattr(self.dense.weight, 'sequence_parallel', config.sequence_parallel)
         setattr(self.dense.bias, 'sequence_parallel', config.sequence_parallel)
 
@@ -160,7 +160,8 @@ class BertModel(MegatronModule):
             self.binary_head = None
             if self.add_binary_head:
                 self.binary_head = get_linear_layer(config.hidden_size, 2,
-                                                    config.init_method)
+                                                    config.init_method,
+                                                    args.zero_stage == 3)
                 self._binary_head_key = 'binary_head'
 
     def set_input_tensor(self, input_tensor):

--- a/megatron/model/biencoder_model.py
+++ b/megatron/model/biencoder_model.py
@@ -273,7 +273,8 @@ class PretrainedBertModel(MegatronModule):
         if args.biencoder_projection_dim > 0:
             self.projection_enc = get_linear_layer(args.hidden_size,
                                                    args.biencoder_projection_dim,
-                                                   init_method)
+                                                   init_method,
+                                                   gather_params_on_init=args.zero_stage == 3)
             self._projection_enc_key = 'projection_enc'
 
     def forward(self, input_ids, attention_mask, tokentype_ids=None):

--- a/megatron/model/classification.py
+++ b/megatron/model/classification.py
@@ -42,7 +42,8 @@ class Classification(MegatronModule):
             self.classification_dropout = torch.nn.Dropout(args.hidden_dropout)
             self.classification_head = get_linear_layer(args.hidden_size,
                                                         self.num_classes,
-                                                        init_method)
+                                                        init_method,
+                                                        gather_params_on_init=args.zero_stage == 3)
             self._classification_head_key = 'classification_head'
 
     def set_input_tensor(self, input_tensor):

--- a/megatron/model/multiple_choice.py
+++ b/megatron/model/multiple_choice.py
@@ -39,7 +39,8 @@ class MultipleChoice(MegatronModule):
         if self.post_process:
             self.multichoice_dropout = torch.nn.Dropout(args.hidden_dropout)
             self.multichoice_head = get_linear_layer(args.hidden_size, 1,
-                                                     init_method)
+                                                     init_method,
+                                                     gather_params_on_init=args.zero_stage == 3)
             self._multichoice_head_key = 'multichoice_head'
 
     def set_input_tensor(self, input_tensor):

--- a/megatron/model/realm_model.py
+++ b/megatron/model/realm_model.py
@@ -163,7 +163,7 @@ class IREncoderBertModel(MegatronModule):
             init_method=init_method,
             scaled_init_method=scaled_init_method)
 
-        self.ict_head = get_linear_layer(args.hidden_size, ict_head_size, init_method)
+        self.ict_head = get_linear_layer(args.hidden_size, ict_head_size, init_method, gather_params_on_init=args.zero_stage == 3)
         self._ict_head_key = 'ict_head'
 
     def forward(self, input_ids, attention_mask, tokentype_ids=None):

--- a/megatron/model/vision/classification.py
+++ b/megatron/model/vision/classification.py
@@ -37,7 +37,8 @@ class VitClassificationModel(MegatronModule):
                 self.head = get_linear_layer(
                     self.hidden_size,
                     self.num_classes,
-                    torch.nn.init.zeros_
+                    torch.nn.init.zeros_,
+                    gather_params_on_init=args.zero_stage == 3
                 )
 
     def set_input_tensor(self, input_tensor):

--- a/megatron/model/vision/inpainting.py
+++ b/megatron/model/vision/inpainting.py
@@ -41,7 +41,8 @@ class VitInpaintingModel(MegatronModule):
             self.linear_decoder = get_linear_layer(
                 self.hidden_size,
                 self.backbone.flatten_dim,
-                torch.nn.init.zeros_
+                torch.nn.init.zeros_,
+                gather_params_on_init=args.zero_stage == 3
             )
 
     def set_input_tensor(self, input_tensor):


### PR DESCRIPTION
In several modules, parameters are initialized outside the constructor. However, these parameters are not initialized when ZeRO3 is enabled. Here is an example:

```python
self.position_embeddings = torch.nn.Embedding(
    max_sequence_length, self.hidden_size)
self._position_embeddings_key = 'position_embeddings'
# Initialize the position embeddings.
if args.perform_initialization:
   self.init_method(self.position_embeddings.weight)
```

`init_method` doesn't work because ZeRO3 sets empty tensor to each Parameter object. This PR fixes this issue by gathering parameters before initialization. Once initialized, these parameters are then broadcasted.