### PR TITLE
fix the CUDA arch and gencode for JIT compiling of fused kernels

### DIFF
--- a/megatron/fused_kernels/__init__.py
+++ b/megatron/fused_kernels/__init__.py
@@ -25,9 +25,18 @@ def load(args):
         if int(bare_metal_major) >= 11:
             cc_flag.append('-gencode')
             cc_flag.append('arch=compute_80,code=sm_80')
-            if int(bare_metal_minor) >= 7:
+            if int(bare_metal_minor) >= 1:
                 cc_flag.append('-gencode')
-                cc_flag.append('arch=compute_90,code=sm_90')
+                cc_flag.append('arch=compute_86,code=sm_86')
+            if int(bare_metal_minor) >= 4:
+                cc_flag.append('-gencode')
+                cc_flag.append('arch=compute_87,code=sm_87')
+            if int(bare_metal_minor) >= 8:
+                cc_flag.append('-gencode')
+                cc_flag.append('arch=compute_89,code=sm_89')
+        if int(bare_metal_major) >= 12:
+            cc_flag.append('-gencode')
+            cc_flag.append('arch=compute_90,code=sm_90')
 
     # Build path
     srcpath = pathlib.Path(__file__).parent.absolute()


### PR DESCRIPTION
I came across the error report of mismatching nvcc version and supported GPU architecture during JIT compiling of fused kernels, error log is listed below:

```bash
FAILED: scaled_upper_triang_masked_softmax_cuda.cuda.o 
/usr/local/cuda/bin/nvcc  -DTORCH_EXTENSION_NAME=scaled_upper_triang_masked_softmax_cuda -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -isystem VENV_PATH/lib/python3.10/site-packages/torch/include -isystem VENV_PATH/lib/python3.10/site-packages/torch/include/torch/csrc/api/include -isystem VENV_PATH/lib/python3.10/site-packages/torch/include/TH -isystem VENV_PATH/lib/python3.10/site-packages/torch/include/THC -isystem /usr/local/cuda/include -isystem VENV_PATH/include/python3.10 -D_GLIBCXX_USE_CXX11_ABI=0 -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_80,code=compute_80 -gencode=arch=compute_80,code=sm_80 --compiler-options '-fPIC' -O3 -gencode arch=compute_70,code=sm_70 --use_fast_math -U__CUDA_NO_HALF_OPERATORS__ -U__CUDA_NO_HALF_CONVERSIONS__ --expt-relaxed-constexpr --expt-extended-lambda -gencode arch=compute_80,code=sm_80 -gencode arch=compute_90,code=sm_90 -std=c++17 -c MEGATRON_DEEPSPEED_PATH/megatron/fused_kernels/scaled_upper_triang_masked_softmax_cuda.cu -o scaled_upper_triang_masked_softmax_cuda.cuda.o 
nvcc fatal   : Unsupported gpu architecture 'compute_90'
```

The version of my nvcc is 11.7.64, which shouldn't support compute_90. This patch fixes the insertion of compiling flags.