### PR TITLE
fix the passing parameter name of GatheredParameters

### DIFF
--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -51,10 +51,10 @@ def get_linear_layer(rows, columns, init_method, gather_params_on_init=False):
     """Simple linear layer with weight initialization."""
     layer = torch.nn.Linear(rows, columns)
     if get_args().perform_initialization:
-        with GatheredParameters(layer.weight, modifier_rank=0, enable=gather_params_on_init):
+        with GatheredParameters(layer.weight, modifier_rank=0, enabled=gather_params_on_init):
             init_method(layer.weight)
     with torch.no_grad():
-        with GatheredParameters(layer.bias, modifier_rank=0, enable=gather_params_on_init):
+        with GatheredParameters(layer.bias, modifier_rank=0, enabled=gather_params_on_init):
             layer.bias.zero_()
     return layer
 


### PR DESCRIPTION
One of the parameters to instantiate `GatheredParameters` should be `enabled` instead of `enable`.

p.s., the definition of [`GatheredParameters`](https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/runtime/zero/partition_parameters.py) is:

```python
class GatheredParameters:

    def __init__(self, params, modifier_rank=None, fwd_module=None, enabled=True):
```