### PR TITLE
Fix: Avoid compromising accuracy by prematurely applying half-precision.

### DIFF
--- a/megatron/model/rotary_pos_embedding.py
+++ b/megatron/model/rotary_pos_embedding.py
@@ -52,5 +52,5 @@ def apply_rotary_pos_emb(t, freqs):
 
     # first part is cosine component
     # second part is sine component, need to change signs with _rotate_half method
-    t = (t * freqs.cos()) + (_rotate_half(t) * freqs.sin())
+    t = (t * freqs.cos().to(t.dtype)) + (_rotate_half(t) * freqs.sin().to(t.dtype))
     return torch.cat((t, t_pass), dim=-1)

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -81,10 +81,6 @@ def model_provider(pre_process=True, post_process=True):
                 # https://github.com/kingoflolz/mesh-transformer-jax/
                 rotary_pos_emb = RotaryEmbedding(rotary_dim)(args.seq_length).to(
                     get_accelerator().current_device_name())
-                if args.fp16:
-                    rotary_pos_emb = rotary_pos_emb.half()
-                elif args.bf16:
-                    rotary_pos_emb = rotary_pos_emb.bfloat16()
                 args.rotary_pos_emb = rotary_pos_emb
 
         else:


### PR DESCRIPTION
I noticed that when running the **llama** model, **the rope embedding is first converted to half-precision and then processed using the cosine function. This approach differs significantly from the method of applying the cosine function first and then converting to half-precision**.

In contrast, both the "**transformers**" and "**xformers**" libraries follow the practice of applying the cosine function first and then converting to half-precision. You can find examples of this in the following code repositories:

Transformers: https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py
Xformers: https://github.com/facebookresearch/xformers/blob/main/xformers/components/positional_embedding/rotary.py

For instance, let's consider an example where the seq-length is set to 2048, and a data sample is randomly selected from the result of the rope_embedding. The data sample, denoted as A, looks like this:

A = [5.1000000000000000e+02, 4.4164181518554688e+02, 3.8244604492187500e+02, ..., 7.8536249697208405e-02, 6.8009600043296814e-02, 5.8893878012895584e-02]

**Method 1: A.half().cos()**:
If we apply the half-precision conversion to A first and then take the cosine, the resulting values will be:
[0.4870605468750000, -0.3486328125000000, 0.7148437500000000, ..., 0.9970703125000000, 0.9975585937500000, 0.9980468750000000]

**Method 2: A.cos().half()**:
On the other hand, if we apply the cosine function to A first and then convert to half-precision, the resulting values will be:
[0.4870605468750000, -0.2454833984375000, 0.6762695312500000, ..., 0.9970703125000000, 0.9975585937500000, 0.9980468750000000]

**It is evident that the results obtained by the two methods are different**. In the given example, (4.4164181518554688e+02).half().cos() equals -0.3486328125000000, while (4.4164181518554688e+02).cos().half() equals -0.2454833984375000. **The difference between the two values is 0.1.**

Therefore, normally **it is advisable to take the cosine first and then convert to half-precision, which can help avoid such significant loss in accuracy**.