### PR TITLE
fix lr schedule when grad accum is active

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -698,7 +698,8 @@ def train_step(forward_step_func, data_iterator,
         increment = get_num_microbatches() * \
                     args.micro_batch_size * \
                     args.data_parallel_size
-        model[0].step(lr_kwargs={'increment': increment})
+        model[0].step(lr_kwargs={'increment': 0}) # grad accum hotfix
+        opt_param_scheduler.step(increment=increment)
         update_successful = model[0].was_step_applied()
     else:
         update_successful, grad_norm, num_zeros_in_grad = optimizer.step(args, timers)


### PR DESCRIPTION
consider this basic setup:
```
MICRO_BATCH_SIZE=2
TRAIN_STEPS=1000
LR=3e-4
MIN_LR=3e-5
LR_WARMUP_STEPS=20
```
and,
```
GLOBAL_BATCH_SIZE=16 # no grad accum
GLOBAL_BATCH_SIZE=32 # grad accum 2
GLOBAL_BATCH_SIZE=1024 # grad accum a lot
```

normal run with no grad accum:
![image](https://github.com/microsoft/Megatron-DeepSpeed/assets/54623771/0b7a22a6-9e36-4c38-9634-386002c7d88c)

run with 2 grad accum:
![image](https://github.com/microsoft/Megatron-DeepSpeed/assets/54623771/631c1470-29ec-4715-8aad-91e9b9814ee0)

run with very big grad accum:
![image](https://github.com/microsoft/Megatron-DeepSpeed/assets/54623771/41eefa24-9c8a-471a-a23e-8bf2da934c29)


---

this two-line fix causes the learning rate scheduler to perform more correctly for me:
![image](https://github.com/microsoft/Megatron-DeepSpeed/assets/54623771/87020103-c24c-4231-b394-7e19345b60cd)
