### PR TITLE
conditionally include cuda_profiler_api.h

### DIFF
--- a/megatron/fused_kernels/scaled_softmax_cuda.cu
+++ b/megatron/fused_kernels/scaled_softmax_cuda.cu
@@ -4,7 +4,9 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#ifndef __HIP_PLATFORM_HCC__
 #include <cuda_profiler_api.h>
+#endif
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/extension.h>
 #include "scaled_masked_softmax.h"


### PR DESCRIPTION
This adds a guard to avoid including ``cuda_profile_api.h`` in ``megatron/fused_kernels/scaled_softmax_cuda.cu`` for builds on AMD systems.

It follow the pattern used in other kernels like:

https://github.com/microsoft/Megatron-DeepSpeed/blob/c2b073624eadabfd898780a6306000db9dee1836/megatron/fused_kernels/scaled_masked_softmax_cuda.cu#L7-L9