### PR TITLE
attempt to enable nvfuser but handle error for ROCm users

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -300,7 +300,11 @@ def set_jit_fusion_options():
         torch._C._jit_override_can_fuse_on_cpu(False)
         torch._C._jit_override_can_fuse_on_gpu(False)
         torch._C._jit_set_texpr_fuser_enabled(False)
-        torch._C._jit_set_nvfuser_enabled(True)
+        try:
+            torch._C._jit_set_nvfuser_enabled(True)
+        except:
+            # catch error thrown on ROCm systems
+            pass
         torch._C._debug_set_autodiff_subgraph_inlining(False)
     else:
         # legacy pytorch fuser


### PR DESCRIPTION
Megatron-DeepSpeed on AMD systems throws the following error:
```
File "/path/to/Megatron-DeepSpeed.git/megatron/initialize.py", line 303, in set_jit_fusion_options
    torch._C._jit_set_nvfuser_enabled(True)
RuntimeError: Running CUDA fuser is only supported on CUDA builds.
```

The nvfuser feature is only valid for Nvidia systems, and explicitly enabling it throws an error for ROCm users.

Reading about nvfuser, it'd be good to get some feedback from AMD on this topic.  It looks like a ROCm equivalent would potentially improve performance:

https://pytorch.org/blog/introducing-nvfuser-a-deep-learning-compiler-for-pytorch/

Long term, that sounds like the best option, but it would require a new PyTorch release.

Short term, to avoid this error on AMD systems, there are different options:

1) This throws an error if explicitly requested but it is not available (what we see now).  If not explicitly requested, I think it is enabled by default if available:

https://github.com/pytorch/pytorch/blob/8507b22fea9ef819452655aa6dd1c42752a4e74a/torch/csrc/jit/codegen/cuda/interface.cpp#L65-L85

In that case, it's probably safe to drop this line for both Nvidia and AMD users.  It would still be enabled by default on Nvidia.

2) Or we could always call it but wrap the call with a ``try/except pass``.

3) Is there a way to test for a ROCm environment and then conditionally enable nvfuser?  I know the DeepSpeed OpBuilder provides an ``is_rocm_pytorch()`` test.  Does it make sense to call down to that here?

To get started, this PR goes with option 2, though option 3 sounds a bit cleaner to me.

Which way would you like to go?