### PR TITLE
rm: remove unused argument of ds_checkpoint_to_megatron

### DIFF
--- a/tools/convert_checkpoint/deepspeed_to_megatron.py
+++ b/tools/convert_checkpoint/deepspeed_to_megatron.py
@@ -78,7 +78,7 @@ def _renest_sd(sd):
     return new_sd
 
 
-def _create_rank_checkpoint(ds_checkpoint, checkpoint_path, tp_index, pp_index, for_release=False):
+def _create_rank_checkpoint(ds_checkpoint, tp_index, pp_index, for_release=False):
     meg_encoder_sd = OrderedDict()
     meg_embedding_sd = OrderedDict()
     meg_embedding_for_head_sd = OrderedDict()


### PR DESCRIPTION
Removed the unused argument of _create_rank_checkpoint() in `tools/convert_checkpoint/deepspeed_to_megatron.py`.
That unused argument can make the deepspeed_to_megatron.py mistakenly ignore model weights from mp_rank_1 and duplicate the weight from rank 0 to higher rank. 