### PR TITLE
[ROCm] Use legacy pytorch fuser or ROCm instead of nvfuser

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -23,6 +23,9 @@ from megatron.model.fused_bias_gelu import bias_gelu
 from megatron.utils import is_rank_0
 from deepspeed.accelerator import get_accelerator
 import deepspeed
+from deepspeed.ops.op_builder.builder import OpBuilder
+
+is_rocm_pytorch = OpBuilder.is_rocm_pytorch()
 
 
 def initialize_megatron(extra_args_provider=None, args_defaults={},
@@ -293,18 +296,14 @@ def set_jit_fusion_options():
     # flags required to enable jit fusion kernels
     TORCH_MAJOR = int(torch.__version__.split('.')[0])
     TORCH_MINOR = int(torch.__version__.split('.')[1])
-    if (TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR >= 10):
+    if ((TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR >= 10)) and not is_rocm_pytorch:
         # nvfuser
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)
         torch._C._jit_override_can_fuse_on_cpu(False)
         torch._C._jit_override_can_fuse_on_gpu(False)
         torch._C._jit_set_texpr_fuser_enabled(False)
-        try:
-            torch._C._jit_set_nvfuser_enabled(True)
-        except:
-            # catch error thrown on ROCm systems
-            pass
+        torch._C._jit_set_nvfuser_enabled(True)
         torch._C._debug_set_autodiff_subgraph_inlining(False)
     else:
         # legacy pytorch fuser


### PR DESCRIPTION
Instead of https://github.com/microsoft/Megatron-DeepSpeed/pull/220, this PR is required for ROCm as we do not currently plan to support nvfuser.
