### PR TITLE
[bug fix]  mpu should be changed to tensor_parallel.

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -182,9 +182,9 @@ def setup_deepspeed_random_and_activation_checkpointing(args):
         synchronize=args.synchronize_each_layer,
         profile=args.profile_backward)
 
-    mpu.checkpoint = deepspeed.checkpointing.checkpoint
-    mpu.get_cuda_rng_tracker = deepspeed.checkpointing.get_cuda_rng_tracker
-    mpu.model_parallel_cuda_manual_seed = deepspeed.checkpointing.model_parallel_cuda_manual_seed
+    tensor_parallel.checkpoint = deepspeed.checkpointing.checkpoint
+    tensor_parallel.get_cuda_rng_tracker = deepspeed.checkpointing.get_cuda_rng_tracker
+    tensor_parallel.model_parallel_cuda_manual_seed = deepspeed.checkpointing.model_parallel_cuda_manual_seed
 
 
 def _initialize_distributed():


### PR DESCRIPTION
in this file ,mpu means parallel_state,does not have checkpoint get_cuda_rng_tracker model_parallel_cuda_manual_seed method , mpu should be changed to tensor_parallel.