### PR TITLE
some modification for activation checkpointing

### DIFF
--- a/examples_deepspeed/pretrain_llama2_distributed.sh
+++ b/examples_deepspeed/pretrain_llama2_distributed.sh
@@ -37,6 +37,10 @@ LR_WARMUP_STEPS=2000
 WEIGHT_DECAY=0.1
 GRAD_CLIP=1
 
+## Activation checkpointing saves GPU memory, but reduces training speed
+# activation_checkpoint="true"
+activation_checkpoint="false"
+
 # Below configuration required for llama model as per llama paper
 # --no-query-key-layer-scaling \
 # --attention-dropout 0 \
@@ -68,7 +72,18 @@ ds_args=""
 ds_args=" --deepspeed ${ds_args}"
 ds_args=" --deepspeed_config=$DS_CONFIG ${ds_args}"
 ds_args=" --zero-stage=$ZERO_STAGE ${ds_args}"
-ds_args=" --deepspeed-activation-checkpointing ${ds_args}"
+
+if [ "${activation_checkpoint}" = "true" ]; then
+  ds_args="--deepspeed-activation-checkpointing ${ds_args}"
+
+  ## old argument for recomputing the transformer layer
+  # ds_args="--checkpoint-activations ${ds_args}"
+
+  ## new argument for recomputing the transformer layer
+  ds_args="--recompute-granularity full --recompute-method uniform ${ds_args}"
+  ## new argument for recomputing only the attention layer
+  # ds_args="--recompute-granularity selective ${ds_args}"
+fi
 
 
 DISTRIBUTED_ARGS="--nproc_per_node $GPUS_PER_NODE --nnodes $NNODES --node_rank $NODE_RANK --master_addr $MASTER_ADDR --master_port $MASTER_PORT"

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -182,10 +182,6 @@ def setup_deepspeed_random_and_activation_checkpointing(args):
         synchronize=args.synchronize_each_layer,
         profile=args.profile_backward)
 
-    mpu.checkpoint = deepspeed.checkpointing.checkpoint
-    mpu.get_cuda_rng_tracker = deepspeed.checkpointing.get_cuda_rng_tracker
-    mpu.model_parallel_cuda_manual_seed = deepspeed.checkpointing.model_parallel_cuda_manual_seed
-
 
 def _initialize_distributed():
     """Initialize torch.distributed and core model parallel."""

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -282,6 +282,9 @@ class GPTModelPipe(PipelineModule,MegatronModule):
 
         if args.checkpoint_activations:
             interval = args.checkpoint_num_layers
+        elif args.recompute_granularity == "full" and args.recompute_method == 'uniform':
+            # deepspeed's pipeline doesn't support the block recompute method
+            interval = args.recompute_num_layers
         else:
             interval = 0
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -608,10 +608,6 @@ class ParallelAttention(MegatronModule):
             input_is_parallel=True,
             skip_bias_add=True)
 
-        if deepspeed.checkpointing.is_configured():
-            global get_cuda_rng_tracker, checkpoint
-            get_cuda_rng_tracker = deepspeed.checkpointing.get_cuda_rng_tracker
-            checkpoint = deepspeed.checkpointing.checkpoint
 
     def _checkpointed_attention_forward(self, query_layer, key_layer,
                                         value_layer, attention_mask,
@@ -1730,10 +1726,6 @@ class ParallelTransformer(MegatronModule):
                         eps=config.layernorm_epsilon)
             else:
                 self.final_layernorm = MixedFusedRMSNorm(config.hidden_size, config.layernorm_epsilon)
-        if deepspeed.checkpointing.is_configured():
-            global get_cuda_rng_tracker, checkpoint
-            get_cuda_rng_tracker = deepspeed.checkpointing.get_cuda_rng_tracker
-            checkpoint = deepspeed.checkpointing.checkpoint
 
     def _get_layer(self, layer_number):
         return self.layers[layer_number]

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -271,7 +271,7 @@ def throughput_calculator(model, args, iteration_time, total_iterations):
     checkpoint_activations_factor = 3
     if hasattr(args, 'checkpoint_activations') and args.checkpoint_activations:
         checkpoint_activations_factor = 4
-    if hasattr(args, 'recompute_granularity') and args.recompute_granularity == 'selective':
+    if hasattr(args, 'recompute_granularity') and (args.recompute_granularity == 'selective' or args.recompute_granularity == 'full'):
         checkpoint_activations_factor = 4
     seq_len = args.seq_length
     if hasattr(args, 'actual_seq_length'):


### PR DESCRIPTION

I have some modification for activation checkpointing.
Firstly, I also found the bug mentioned by the [PR](https://github.com/microsoft/Megatron-DeepSpeed/pull/241). Exactly, I tried the same method to fix this bug and got the same result. It doesn't work. After I read the code, I found the code(https://github.com/microsoft/Megatron-DeepSpeed/blob/c08e2cc2579cf7ef5ce6ad58453e76a5710b7b6b/megatron/core/tensor_parallel/layers.py#L35C16-L35C16) probably be executed before the function replaced. So it will keep to use the function of Megatron-LM.
Secondly, I found I can not use the recompute-granularity and recompute-method arguments to recompute the transformer layer when I pretrain the llama model with pipeline parallelism, but can recompute the attention layer(`--recompute-granularity selective`). I think they should be both supported. 