### PR TITLE
support transfer llama hf weight to megatron weight

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -222,14 +222,17 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler):
     if not args.deepspeed:
         model = unwrap_model(model)
 
-    print_rank_0('saving checkpoint at iteration {:7d} to {}'.format(
+    print_rank_0('saving checkpoint at iteration {} to {}'.format(
         iteration, args.save))
 
     # Collect rng state across data parallel ranks.
     rng_state = get_rng_state()
 
     # Checkpoint name.
-    checkpoint_name = get_checkpoint_name(args.save, iteration)
+    if iteration == 'release':
+        checkpoint_name = get_checkpoint_name(args.save, iteration, release=True)
+    else:
+        checkpoint_name = get_checkpoint_name(args.save, iteration)
 
     # Save distributed optimizer's custom parameter state.
     if args.use_distributed_optimizer:
@@ -300,7 +303,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler):
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
-    print_rank_0('  successfully saved checkpoint at iteration {:7d} to {}' \
+    print_rank_0('  successfully saved checkpoint at iteration {} to {}' \
                  .format(iteration, args.save))
 
     # And update the latest iteration

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -512,6 +512,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
     _set_arg('apply_layernorm_1p', force=True)
     _set_arg('tokenizer_type')
     _set_arg('padded_vocab_size')
+    _set_arg('normalization', force=True)
     if checkpoint_version < 3.0:
         _set_arg('tensor_model_parallel_size',
                  'model_parallel_size')

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -584,9 +584,11 @@ class ParallelAttention(MegatronModule):
             local_attn = FlashSelfAttention(causal=True, attention_dropout=config.attention_dropout)
         else:
             local_attn = CoreAttention(self.layer_number, config, self.attn_mask_type)
-        # self.enable_ds_sequence_parallel = parallel_state.get_sequence_parallel_world_size() > 1 \
-        #                                    or args.force_ds_sequence_parallel
-        self.enable_ds_sequence_parallel = False
+        if hasattr(args, 'ckpt_transfer') and args.ckpt_transfer:
+            self.enable_ds_sequence_parallel = False
+        else:
+            self.enable_ds_sequence_parallel = parallel_state.get_sequence_parallel_world_size() > 1 \
+                                            or args.force_ds_sequence_parallel
         if self.enable_ds_sequence_parallel:
             assert dist_attn_supported, 'Distributed attention is not supported in this DeepSpeed version'
             assert args.num_attention_heads % parallel_state.get_sequence_parallel_world_size() == 0

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -584,9 +584,9 @@ class ParallelAttention(MegatronModule):
             local_attn = FlashSelfAttention(causal=True, attention_dropout=config.attention_dropout)
         else:
             local_attn = CoreAttention(self.layer_number, config, self.attn_mask_type)
-
-        self.enable_ds_sequence_parallel = parallel_state.get_sequence_parallel_world_size() > 1 \
-                                           or args.force_ds_sequence_parallel
+        # self.enable_ds_sequence_parallel = parallel_state.get_sequence_parallel_world_size() > 1 \
+        #                                    or args.force_ds_sequence_parallel
+        self.enable_ds_sequence_parallel = False
         if self.enable_ds_sequence_parallel:
             assert dist_attn_supported, 'Distributed attention is not supported in this DeepSpeed version'
             assert args.num_attention_heads % parallel_state.get_sequence_parallel_world_size() == 0

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -28,7 +28,8 @@ import subprocess
 from torch import nn
 import torch.nn.functional as F
 
-def model_provider(pre_process=True, post_process=True):
+
+def model_provider(pre_process=True, post_process=True, ckpt_transfer_model=False):
     """Build the model."""
 
     print_rank_0('building GPT model ...')
@@ -36,6 +37,14 @@ def model_provider(pre_process=True, post_process=True):
 
     args = get_args()
     config = core_transformer_config_from_args(args)
+    
+    if ckpt_transfer_model:
+        return GPTModel(config=config,
+                    num_tokentypes=0,
+                    parallel_output=True,
+                    pre_process=pre_process,
+                    post_process=post_process)
+    
     with deepspeed.zero.Init(sequence_data_parallel_group=mpu.get_sequence_data_parallel_group(),
                              remote_device=None if args.remote_device == 'none' else args.remote_device,
                              config_dict_or_path=args.deepspeed_config,

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -56,9 +56,9 @@ def _load_checkpoint(queue, args):
 
     margs = parse_args()
     margs, checkpoint_args = load_args_from_checkpoint(margs)
-    margs.tokenizer_model = "/mnt/dolphinfs/hdd_pool/docker/share/llama2_13b_base/tokenizer.model"
-    margs.force_ds_sequence_parallel = False
-    margs.normalization = 'rmsnorm'
+    if args.tokenizer_model:
+        margs.tokenizer_model = args.tokenizer_model
+    margs.ckpt_transfer = True
 
     # Arguments do sanity checks on the world size, but we don't care,
     # so trick it into thinking we are plenty of processes

--- a/tools/checkpoint_saver_megatron.py
+++ b/tools/checkpoint_saver_megatron.py
@@ -160,7 +160,6 @@ def save_checkpoint(queue, args):
             if getattr(margs, arg) != value:
                 print(f"Overwriting default {arg} value {getattr(margs, arg)} with value from checkpoint {value}.")
                 setattr(margs, arg, value)
-    margs.tokenizer_model = "/mnt/dolphinfs/hdd_pool/docker/share/llama2_13b_base/tokenizer.model"
 
     validate_args(margs)
 
@@ -168,6 +167,7 @@ def save_checkpoint(queue, args):
 
     # margs = megatron args
     margs = get_args()
+    margs.ckpt_transfer = True
 
     if hasattr(md, 'consumed_train_samples'):
         margs.consumed_train_samples = md.consumed_train_samples

--- a/tools/checkpoint_util.py
+++ b/tools/checkpoint_util.py
@@ -124,8 +124,12 @@ def main():
     parser.add_argument('--no-checking', action='store_false',
                         help='Do not perform checking on the name and ordering of weights',
                         dest='checking')
+    parser.add_argument('--tokenizer-model', type=str, default=None,
+                        help='tokenizer-model, should be on python path')
+
 
     known_args, _ = parser.parse_known_args()
+    
     loader = load_plugin('loader', known_args.loader)
     saver = load_plugin('saver', known_args.saver)
 
@@ -133,7 +137,8 @@ def main():
     saver.add_arguments(parser)
 
     args = parser.parse_args()
-
+    if args.tokenizer_model is None:
+        args.tokenizer_model = args.load_dir+"/tokenizer.model"
     queue = mp.Queue(maxsize=args.max_queue_size)
 
     print("Starting saver...")


### PR DESCRIPTION
Hi there,

I hope this message finds you well. I would like to request the availability of the pretrained checkpoint for the pretrain and SFT stages of the project. Currently, there is no corresponding checkpoint available for llama2 in the Megatron repository.

To address this issue, I have modify a script  from [that](https://github.com/epfLLM/Megatron-LLM/tree/main/weights_conversion) facilitates the conversion from hf (Hugging Face) format to Megatron format. This script will enable the usage of llama2's pretrained checkpoint in the Megatron framework.

Please let me know if there are any further steps required or if you need any additional information from my end to proceed with this request.

Thank you for your attention and assistance.

Best regards,