### PR TITLE
Minor fixes 

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -93,7 +93,7 @@ def validate_args(args, defaults={}):
     model_parallel_size = args.pipeline_model_parallel_size * \
                           args.tensor_model_parallel_size * \
                           args.ds_sequence_parallel_size
-    assert args.world_size % model_parallel_size == 0, 'world size is not'\
+    assert args.world_size % model_parallel_size == 0, 'world size ({}) is not'\
         ' divisible by tensor parallel size ({}) times pipeline parallel ' \
         'size ({})'.format(args.world_size, args.tensor_model_parallel_size,
                            args.pipeline_model_parallel_size)

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -7,6 +7,7 @@ import math
 import os
 from typing import Optional, Callable
 import warnings
+from packaging import version
 
 import torch
 import torch.nn.functional as F
@@ -253,10 +254,18 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
 
             all_gather_buffer = \
                 get_global_memory_buffer().get_tensor(dim_size, input.dtype, "mpu")
-            torch.distributed.all_gather_into_tensor(
-                all_gather_buffer,
-                input,
-                group=get_tensor_model_parallel_group())
+
+            if version.parse(torch.__version__) >= version.parse('1.13'):
+                torch.distributed.all_gather_into_tensor(
+                    all_gather_buffer,
+                    input,
+                    group=get_tensor_model_parallel_group())
+            else:
+                torch.distributed._all_gather_base(
+                    all_gather_buffer,
+                    input,
+                    group=get_tensor_model_parallel_group())
+
             total_input = all_gather_buffer
         else:
             total_input = input

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -253,7 +253,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
 
             all_gather_buffer = \
                 get_global_memory_buffer().get_tensor(dim_size, input.dtype, "mpu")
-            torch.distributed._all_gather_base(
+            torch.distributed.all_gather_into_tensor(
                 all_gather_buffer,
                 input,
                 group=get_tensor_model_parallel_group())
@@ -279,7 +279,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
 
             all_gather_buffer = \
                 get_global_memory_buffer().get_tensor(dim_size, input.dtype, "mpu")
-            handle = torch.distributed._all_gather_base(
+            handle = torch.distributed.all_gather_into_tensor(
                 all_gather_buffer,
                 input,
                 group=get_tensor_model_parallel_group(), async_op=True)

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -99,7 +99,7 @@ def _gather_along_first_dim(input_):
 
     output = torch.empty(dim_size, dtype=input_.dtype,
                          device=torch.cuda.current_device())
-    torch.distributed._all_gather_base(output, input_.contiguous(),
+    torch.distributed.all_gather_into_tensor(output, input_.contiguous(),
                                        group=get_tensor_model_parallel_group())
 
     return output

--- a/megatron/core/tensor_parallel/utils.py
+++ b/megatron/core/tensor_parallel/utils.py
@@ -80,7 +80,7 @@ def gather_split_1d_tensor(tensor):
     # as opposed to torch.distributed.all_gather for efficiency reasons.
     # This API calls directly NCCL all-gather versus the former does
     # internal copies and can potentially cause slow down.
-    torch.distributed._all_gather_base(gathered, tensor,
+    torch.distributed.all_gather_into_tensor(gathered, tensor,
                                        group=parallel_state.get_tensor_model_parallel_group())
     return gathered
 

--- a/megatron/core/tensor_parallel/utils.py
+++ b/megatron/core/tensor_parallel/utils.py
@@ -2,6 +2,7 @@
 
 import torch
 from typing import List, Sequence
+from packaging import version
 
 from megatron.core.utils import divide
 from megatron.core import parallel_state
@@ -80,8 +81,13 @@ def gather_split_1d_tensor(tensor):
     # as opposed to torch.distributed.all_gather for efficiency reasons.
     # This API calls directly NCCL all-gather versus the former does
     # internal copies and can potentially cause slow down.
-    torch.distributed.all_gather_into_tensor(gathered, tensor,
+    if version.parse(torch.__version__) >= version.parse('1.13'):
+        torch.distributed.all_gather_into_tensor(gathered, tensor,
                                        group=parallel_state.get_tensor_model_parallel_group())
+    else:
+        torch.distributed._all_gather_base(gathered, tensor,
+                                       group=parallel_state.get_tensor_model_parallel_group())
+
     return gathered
 
 

--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -781,7 +781,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         ranks.
 
         Additionally, return references to the entire buffers, for use
-        in _reduce_scatter_base and _all_gather_base.
+        in _reduce_scatter_base and all_gather_into_tensor.
         """
 
         data_parallel_world_size = mpu.get_data_parallel_world_size()
@@ -886,7 +886,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for index, (model_index, dtype, pbuf, pbuf_views) \
             in enumerate(pbuf_view_items):
 
-            torch.distributed._all_gather_base(
+            torch.distributed.all_gather_into_tensor(
                 pbuf,
                 pbuf_views[data_parallel_rank],
                 group = data_parallel_group,

--- a/megatron/timers.py
+++ b/megatron/timers.py
@@ -197,7 +197,7 @@ class Timers:
                     reset=reset)
 
         # See the note above for why we are not using gather.
-        torch.distributed._all_gather_base(rank_name_to_time.view(-1),
+        torch.distributed.all_gather_into_tensor(rank_name_to_time.view(-1),
                                            rank_name_to_time[rank, :].view(-1))
 
         return rank_name_to_time

--- a/megatron/timers.py
+++ b/megatron/timers.py
@@ -8,6 +8,7 @@ import time
 
 import torch
 from deepspeed.accelerator import get_accelerator
+from packaging import version
 
 
 class TimerBase(ABC):
@@ -197,8 +198,12 @@ class Timers:
                     reset=reset)
 
         # See the note above for why we are not using gather.
-        torch.distributed.all_gather_into_tensor(rank_name_to_time.view(-1),
+        if version.parse(torch.__version__) >= version.parse('1.13'):
+            torch.distributed.all_gather_into_tensor(rank_name_to_time.view(-1),
                                            rank_name_to_time[rank, :].view(-1))
+        else:
+            torch.distributed._all_gather_base(rank_name_to_time.view(-1),
+                                         rank_name_to_time[rank, :].view(-1))
 
         return rank_name_to_time
 


### PR DESCRIPTION
## Overveiw

1. `torch.distributed._all_gather_base` → `torch.distributed.all_gather_into_tensor`
2.  fix format sentence  (`megatron/arguments.py`)

## Detail

 I was receiving warnings like this

```
Megatron-DeepSpeed/.env/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:2562: UserWarning: torch.distributed._all_gather_base is a private function and will be deprecated. Please use torch.distributed.all_gather_into_tensor instead.
```

so, I changed `_all_gather_base` into `all_gather_into_tensor`.

I confirmed that distributed learning is possible with 8 GPUs after this changes.

FYI:

`_all_gather_base`: https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py#L2909-L2936
`all_gather_into_tensor`: https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py#L2820-L2906


