### PR TITLE
fix flashattention arg

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -877,7 +877,7 @@ def _add_training_args(parser):
     group.add_argument('--create-moe-param-group', action='store_true',
                        help='Create separate groups for MoE params.'
                        'This is necessary for techniques like ZeRO.')
-    group.add_argument('--use-flash-attn-v1', action='store_true',
+    group.add_argument('--use-flash-attn', '--use-flash-attn-v1', dest='use_flash_attn_v1', action='store_true',
                        help='use first version FlashAttention implementation of attention. '
                        'https://arxiv.org/abs/2205.14135')
     group.add_argument('--use-flash-attn-v2', action='store_true',

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -404,6 +404,9 @@ def validate_args(args):
     args.curriculum_learning_legacy = False
     args.compression_training = False
 
+    # FlashAttention
+    args.use_flash_attn = args.use_flash_attn_v1 or args.use_flash_attn_triton or args.use_flash_attn_v2
+
     # AML
     if args.aml_data_download_path is not None:
         data_paths = []
@@ -874,7 +877,7 @@ def _add_training_args(parser):
     group.add_argument('--create-moe-param-group', action='store_true',
                        help='Create separate groups for MoE params.'
                        'This is necessary for techniques like ZeRO.')
-    group.add_argument('--use-flash-attn', '--use-flash-attn-v1', dest='use_flash_attn_v1', action='store_true',
+    group.add_argument('--use-flash-attn-v1', action='store_true',
                        help='use first version FlashAttention implementation of attention. '
                        'https://arxiv.org/abs/2205.14135')
     group.add_argument('--use-flash-attn-v2', action='store_true',


### PR DESCRIPTION
This PR fixes the following error (when pipeline parallelism is not used):

```
File "/vc_data/users/conglli/code/Megatron-DeepSpeed-main/examples_deepspeed/rebase/../../pretrain_gpt.py", line 121, in get_batch
    skip_mask = args.use_flash_attn or args.use_flash_attn_triton
AttributeError: 'Namespace' object has no attribute 'use_flash_attn'
```