### PR TITLE
Disable elastic checkpointing in ds_config templates

### DIFF
--- a/examples_deepspeed/MoE/ds_config_gpt_TEMPLATE.json
+++ b/examples_deepspeed/MoE/ds_config_gpt_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/bert_with_pile/ds_config_bert_TEMPLATE.json
+++ b/examples_deepspeed/bert_with_pile/ds_config_bert_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/compression/ds_config_gpt_TEMPLATE.json
+++ b/examples_deepspeed/compression/ds_config_gpt_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/compression/ds_config_gpt_TEMPLATE_compression.json
+++ b/examples_deepspeed/compression/ds_config_gpt_TEMPLATE_compression.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/bert/finetune/ds_config_bert_TEMPLATE.json
+++ b/examples_deepspeed/data_efficiency/bert/finetune/ds_config_bert_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/bert/finetune_glue/ds_config_bert_TEMPLATE.json
+++ b/examples_deepspeed/data_efficiency/bert/finetune_glue/ds_config_bert_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/bert/pretrain/ds_config_bert_1clmetric_TEMPLATE.json
+++ b/examples_deepspeed/data_efficiency/bert/pretrain/ds_config_bert_1clmetric_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/bert/pretrain/ds_config_bert_2clmetrics_TEMPLATE.json
+++ b/examples_deepspeed/data_efficiency/bert/pretrain/ds_config_bert_2clmetrics_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/gpt/eval/ds_config_eval_dummy.json
+++ b/examples_deepspeed/data_efficiency/gpt/eval/ds_config_eval_dummy.json
@@ -4,8 +4,7 @@
 "steps_per_print": 10,
 
 "zero_optimization": {
-    "stage": 0,
-    "elastic_checkpoint": true
+    "stage": 0
 },
 
 "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/gpt/pretrain/ds_config_gpt_1clmetric_TEMPLATE.json
+++ b/examples_deepspeed/data_efficiency/gpt/pretrain/ds_config_gpt_1clmetric_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/data_efficiency/gpt/pretrain/ds_config_gpt_2clmetrics_TEMPLATE.json
+++ b/examples_deepspeed/data_efficiency/gpt/pretrain/ds_config_gpt_2clmetrics_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/deepspeed4science/megatron_long_seq_support/ds_config_gpt_TEMPLATE.json
+++ b/examples_deepspeed/deepspeed4science/megatron_long_seq_support/ds_config_gpt_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/rebase/ds_config_gpt_TEMPLATE.json
+++ b/examples_deepspeed/rebase/ds_config_gpt_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,

--- a/examples_deepspeed/sequence_parallel/ds_config_gpt_TEMPLATE.json
+++ b/examples_deepspeed/sequence_parallel/ds_config_gpt_TEMPLATE.json
@@ -4,8 +4,7 @@
   "steps_per_print": LOG_INTERVAL,
 
   "zero_optimization": {
-    "stage": ZERO_STAGE,
-    "elastic_checkpoint": true
+    "stage": ZERO_STAGE
   },
 
   "gradient_clipping": 1.0,


### PR DESCRIPTION
This PR removes the option to enable elastic checkpointing because the feature is currently experimental.