### PR TITLE
fix the config file unclose

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -69,8 +69,8 @@ So, we use ds_config dict which is the more flexible option.
 '''
 def _create_ds_config_dict():
     args = get_args()
-    ds_config_dict = json.load(
-        open(args.deepspeed_config, 'r', encoding='utf-8'))
+    with open(args.deepspeed_config, 'r', encoding='utf-8') as config_file:
+        ds_config_dict = json.load(config_file)
     
     if args.universal_checkpoint:
         ds_config_dict["checkpoint"] = {"load_universal": True}


### PR DESCRIPTION
We have a runtime checker, and it report: 
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='deepspeed_config_13B.json' mode='r' encoding='utf-8'>
  open(args.deepspeed_config, 'r', encoding='utf-8'))
```
Because when json.load(open()), it never close.