### PR TITLE
fix when params_have_main_grad

### DIFF
--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -113,7 +113,7 @@ def get_megatron_optimizer(model,
 
     # Determine whether the params have main-grad field.
     params_have_main_grad = False
-    if args.DDP_impl == 'local':
+    if args.use_contiguous_buffers_in_local_ddp:
         params_have_main_grad = True
 
     # Mixed precision optimizer.


### PR DESCRIPTION
In DistributedDataParallel class, when we [use_contiguous_buffers](https://github.com/microsoft/Megatron-DeepSpeed/blob/efd714b930d877e518e91d3fd50174a7f66639ef/megatron/model/distributed.py#L111C1-L111C40), the params will create main_grad attribute.

But when we get optimizer with params_have_main_grad , we judge [`args.DDP_impl == 'local'`](https://github.com/microsoft/Megatron-DeepSpeed/blob/efd714b930d877e518e91d3fd50174a7f66639ef/megatron/optimizer/__init__.py#L116C1-L116C33):
```python
if args.DDP_impl == 'local':
        params_have_main_grad = True
```
However, when DDP_impl == 'local', [it is uncertain to use contiguous_buffers](https://github.com/microsoft/Megatron-DeepSpeed/blob/efd714b930d877e518e91d3fd50174a7f66639ef/megatron/arguments.py#L195C1-L196C57):
```python
if args.DDP_impl != 'local':
        args.use_contiguous_buffers_in_local_ddp = False
```


So, the judgement `if args.DDP_impl == 'local'` is not true, it will use `if args.use_contiguous_buffers_in_local_ddp` to make params_have_main_grad .

