### PR TITLE
transformer.py: avoid building flash_attn op when unset use_flash_attn

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -47,12 +47,8 @@ try:
 except ImportError:
     flash_attn_varlen_func = None
 
-
 FlashAttentionBuilder = get_accelerator().get_op_builder("FlashAttentionBuilder")
-try:
-    flash_attn_builder = FlashAttentionBuilder().load()
-except TypeError:
-    flash_attn_builder = None
+flash_attn_builder = None
 
 try:
     from apex.normalization import MixedFusedRMSNorm
@@ -505,6 +501,11 @@ class ParallelAttention(MegatronModule):
             and self.attn_mask_type == AttnMaskType.causal
         self.use_flash_attn_triton = args.use_flash_attn_triton
         if self.use_flash_attn:
+            try:
+                flash_attn_builder = FlashAttentionBuilder().load()
+            except TypeError:
+                flash_attn_builder = None
+
             if args.use_flash_attn_v1:
                 assert flash_attn_unpadded_func != None or flash_attn_builder != None, ("Cannot import FlashAttention v1 "
                                                                                         "and Cannot find FlashAttention Builder")

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -501,6 +501,7 @@ class ParallelAttention(MegatronModule):
             and self.attn_mask_type == AttnMaskType.causal
         self.use_flash_attn_triton = args.use_flash_attn_triton
         if self.use_flash_attn:
+            global flash_attn_builder
             try:
                 flash_attn_builder = FlashAttentionBuilder().load()
             except TypeError:


### PR DESCRIPTION
Move FlashAttenBuilder().load() to the function ParallelAttention to avoid ops building while not setting use_flash_attn