### PR TITLE
delete redundancy code

### DIFF
--- a/megatron/model/distributed.py
+++ b/megatron/model/distributed.py
@@ -217,7 +217,6 @@ class DistributedDataParallel(DistributedDataParallelBase):
                     if tp not in buckets:
                         buckets[tp] = []
                     buckets[tp].append(param)
-                    param.main_grad = param.grad
 
             # For each bucket, all-reduce and copy all-reduced grads.
             for tp in buckets:


### PR DESCRIPTION
There was two bugs in [this old pr](https://github.com/microsoft/Megatron-DeepSpeed/commit/b4bc51b1e710966b4985f0a09ad114362b3c75f9), one is that use `args.DDP_impl == 'local'` to make `params_have_main_grad` True, but not use `args.use_contiguous_buffers_in_local_ddp`, so when `args.DDP_impl == 'local'` but not use contiguous_buffers, the optimizer will also use main_grad:([This bug is fixed.](https://github.com/microsoft/Megatron-DeepSpeed/pull/272))
```python
if args.DDP_impl == 'local':
        params_have_main_grad = True
```

The other one is that [add irrelevant code `param.main_grad = param.grad` in func `allreduce_gradients`](https://github.com/microsoft/Megatron-DeepSpeed/blob/6a8b2f589d20e2e162a47e3986fef774b42c318b/megatron/model/distributed.py#L220C3-L220C3) to avoid the first error.
Because when `args.DDP_impl == 'local'` but not use contiguous_buffers, the optimizer will also use main_grad, so the old pr add `param.main_grad = param.grad` in func `allreduce_gradients`, that create main_grad attribute in param even there is no contiguous_buffers, so there is no acceleration effect, but only makes optimizer do not raise error.

But now, we [fixed the first bug](https://github.com/microsoft/Megatron-DeepSpeed/pull/272), so the irrelevant code `param.main_grad = param.grad` in func `allreduce_gradients` does not need, and the irrelevant code is context-independent. It is so strange to reserve it.

--------------------------------------------------

By the way, how do we discover this bug? 
We use Lora's `modules_to_save`, it will create an `original_module.weight` but not train, so it has `requires_grad` but the `grad` is None. When we training in `args.DDP_impl == 'local'` and not use contiguous_buffers, the func `allreduce_gradients` will judge `if param.requires_grad and param.grad is not None`, so the `original_module.weight` does not have `mian_grad`. But because of the first bug, the optimizer will also use `main_grad`......

And we feel weird about why when we use  `'local'`  and no contiguous_buffers, it also can run before fixed the first bug(because the params_have_main_grad is True). So we discover the `param.main_grad = param.grad` code.