### PR TITLE
Universal ckp fixes

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -664,7 +664,6 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
             if 'rng_state' in state_dict:
                 # access rng_state for data parallel rank
                 if args.data_parallel_random_init:
-
                     rng_state = state_dict['rng_state'][mpu.get_data_parallel_rank()]
                 else:
                     rng_state = state_dict['rng_state'][0]
@@ -693,6 +692,28 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
                          'attempting to load the rng state, '
                          'exiting ...'.format(checkpoint_name))
             sys.exit()
+
+        if args.universal_checkpoint:
+            # TLDR: unique rng is needed for dropout to be really random on TP ranks
+            #
+            # Each tp-rank stores its model-parallel-rng states info.
+            # This is required to e.g. have different dropout patterns on different tp ranks that operate on
+            # slices of attention_probs tensor.
+            #
+            # When loading from universal checkpoint, we use mp_rank_<mp>_model_states.pt checkpoint files
+            # to restore the model-parallel-rng (<mp> is {tp-rank, pp-rank} combination).
+            # However, if the loaded checkpoint mp configuration does not match the current mp configuration,
+            # we can not use it to restore model-parallel-rng info.
+            #
+            # In the case of mp configuration change, we reconfigure the model-parallel-rng states s.t. each
+            # tp-rank will have a unique state. In order to ensure that subsequent loads from universal will
+            # not cause the model-parallel-rng states to be repeated, we add the iteration number to the base seed.
+            ckp_args = state_dict['args']
+            if ((args.tensor_model_parallel_size != ckp_args.tensor_model_parallel_size)
+                    or (args.pipeline_model_parallel_size != ckp_args.pipeline_model_parallel_size)):
+                print_rank_0(' loading universal checkpoint with modified mp configuration '
+                             '-> reconfigure tp seed')
+                tensor_parallel.model_parallel_reconfigure_tp_seed(args.seed + iteration)
 
     # Some utilities want to load a checkpoint without distributed being initialized
     if torch.distributed.is_initialized():

--- a/megatron/core/tensor_parallel/__init__.py
+++ b/megatron/core/tensor_parallel/__init__.py
@@ -25,6 +25,7 @@ from .random import (
     checkpoint,
     get_cuda_rng_tracker,
     model_parallel_cuda_manual_seed,
+    model_parallel_reconfigure_tp_seed,
     init_checkpointed_activations_memory_buffer,
     reset_checkpointed_activations_memory_buffer,
 )

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -219,6 +219,15 @@ def model_parallel_cuda_manual_seed(seed):
                                 tensor_model_parallel_seed)
 
 
+def model_parallel_reconfigure_tp_seed(seed):
+    if deepspeed.checkpointing.is_configured():
+        return deepspeed.checkpointing.model_parallel_reconfigure_tp_seed(seed)
+
+    model_parallel_seed = seed + 2718 + get_tensor_model_parallel_rank()
+    with _CUDA_RNG_STATE_TRACKER.fork():
+        get_accelerator().manual_seed(model_parallel_seed)
+
+
 class CheckpointFunction(torch.autograd.Function):
     """This function is adapted from torch.utils.checkpoint with
        two main changes:

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -206,7 +206,7 @@ class GPTModel(MegatronModule):
             # Parameter that are sliced on the row dimension
             info[PARAMETER_WITH_ROW_PARALLELISM_PATTERNS] = [
                 r"\d+.mlp.dense_4h_to_h.weight",
-                r"\d+.mlp.self_attention.dense.weight",
+                r"\d+.self_attention.dense.weight",
             ]
 
         return info
@@ -372,7 +372,6 @@ class GPTModelPipe(PipelineModule,MegatronModule):
             # Parameter that are sliced on the row dimension
             info[PARAMETER_WITH_ROW_PARALLELISM_PATTERNS] = [
                 r"\d+.mlp.dense_4h_to_h.weight",
-                r"\d+.mlp.self_attention.dense.weight",
+                r"\d+.self_attention.dense.weight",
             ]
-
         return info

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -190,8 +190,6 @@ class GPTModel(MegatronModule):
 
             # Parameter slices that should be averaged not concatenated.
             info[TP_REPLICATED_PARAMETER_PATTERNS] = [
-                r"tied_modules.embed.word_embeddings.norm.weight",
-                r"tied_modules.embed.word_embeddings.norm.bias",
                 r"tied_modules.embed.position_embeddings.weight",
                 r"\d+.input_layernorm.weight",
                 r"\d+.input_layernorm.bias",
@@ -356,8 +354,6 @@ class GPTModelPipe(PipelineModule,MegatronModule):
 
             # Parameter slices that should be averaged not concatenated.
             info[TP_REPLICATED_PARAMETER_PATTERNS] = [
-                r"tied_modules.embed.word_embeddings.norm.weight",
-                r"tied_modules.embed.word_embeddings.norm.bias",
                 r"tied_modules.embed.position_embeddings.weight",
                 r"\d+.input_layernorm.weight",
                 r"\d+.input_layernorm.bias",


### PR DESCRIPTION
This PR fixes few issues in loading from universal checkpoint.
With this fixes, it is ok to load from universal checkpoint and change all 3D dimensions (data / tensor / pipeline).
For testing of the changes, I used a 4-layers toy model of GPT-Large with BF16.

Following is TensorBoard with:
- Base run using DP=2 TP=2 PP=2 for 200 iterations
- Load from universal checkpoint at iteration 100 and run till iteration 200 with configurations:
  DP=1 TP=2 PP=2
  DP=2 TP=1 PP=2
  DP=1 TP=4 PP=2
  DP=1 TP=4 PP=1
  DP=8 TP=1 PP=1
  DP=4 TP=1 PP=2

As can be seen, both training loss and validation loss are similar across all runs.

![universal-bf16-results](https://github.com/microsoft/Megatron-DeepSpeed/assets/26796709/c6eb1ca3-1160-4aa2-9e93-25ede7dc5547)

Note that this PR is dependent on https://github.com/microsoft/DeepSpeed/pull/4588
