### PR TITLE
Introduce LayerNorm optimization from latest Apex

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -462,6 +462,7 @@ def core_transformer_config_from_args(args):
             kw_args[f.name] = getattr(args, f.name)
     kw_args['persist_layer_norm'] = not args.no_persist_layer_norm
     kw_args['layernorm_zero_centered_gamma'] = args.apply_layernorm_1p
+    kw_args['mem_efficient_ln'] = not args.disable_mem_efficient_ln
     kw_args['deallocate_pipeline_outputs'] = True
     kw_args['pipeline_dtype'] = args.params_dtype
     kw_args['batch_p2p_comm'] = not args.overlap_p2p_comm
@@ -626,6 +627,9 @@ def _add_network_size_args(parser):
     group.add_argument('--apply-layernorm-1p', action='store_true',
                        help='Adjust LayerNorm weights such that they are centered '
                        'around zero. This improves numerical stability.')
+    group.add_argument('--disable-mem-efficient-ln', action='store_false', 
+                       help='Disable the memory-efficient fused LayerNorm optimization '
+                       'introduced in https://github.com/NVIDIA/apex/pull/1715')
     group.add_argument('--apply-residual-connection-post-layernorm',
                        action='store_true',
                        help='If set, use original BERT residula connection '

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -462,7 +462,6 @@ def core_transformer_config_from_args(args):
             kw_args[f.name] = getattr(args, f.name)
     kw_args['persist_layer_norm'] = not args.no_persist_layer_norm
     kw_args['layernorm_zero_centered_gamma'] = args.apply_layernorm_1p
-    kw_args['mem_efficient_ln'] = not args.disable_mem_efficient_ln
     kw_args['deallocate_pipeline_outputs'] = True
     kw_args['pipeline_dtype'] = args.params_dtype
     kw_args['batch_p2p_comm'] = not args.overlap_p2p_comm

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -31,10 +31,12 @@ class MixedFusedLayerNorm(torch.nn.Module):
   def __init__(self, normalized_shape, eps=1e-5,
                no_persist_layer_norm=True,
                sequence_parallel=False,
-               apply_layernorm_1p=False):
+               apply_layernorm_1p=False,
+               mem_efficient_ln=True):
         super(MixedFusedLayerNorm, self).__init__()
 
         self.apply_layernorm_1p = apply_layernorm_1p
+        self.mem_efficient_ln = mem_efficient_ln
 
         global fused_layer_norm_cuda
         fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -83,7 +85,7 @@ class MixedFusedLayerNorm(torch.nn.Module):
         return F.layer_norm(input, self.normalized_shape, weight, self.bias, self.eps)
 
     if self.no_persist_layer_norm:
-        return FusedLayerNormAffineFunction.apply(input, weight, self.bias, self.normalized_shape, self.eps)
+        return FusedLayerNormAffineFunction.apply(input, weight, self.bias, self.normalized_shape, self.eps, self.mem_efficient_ln)
     else:
         output = FastLayerNormFN.apply(input, weight, self.bias, self.eps)
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -920,7 +920,7 @@ class ParallelTransformerLayer(MegatronModule):
                     no_persist_layer_norm=args.no_persist_layer_norm,
                     sequence_parallel=config.sequence_parallel,
                     apply_layernorm_1p=args.apply_layernorm_1p,
-                    mem_efficient_ln=args.mem_efficient_ln)
+                    mem_efficient_ln=not args.disable_mem_efficient_ln)
             else:
                 self.input_layernorm = LayerNorm(
                     config.hidden_size,
@@ -946,7 +946,7 @@ class ParallelTransformerLayer(MegatronModule):
                     no_persist_layer_norm=not config.persist_layer_norm,
                     sequence_parallel=config.sequence_parallel,
                     apply_layernorm_1p=args.apply_layernorm_1p,
-                    mem_efficient_ln=args.mem_efficient_ln)
+                    mem_efficient_ln=not args.disable_mem_efficient_ln)
             else:
                 self.post_attention_layernorm = LayerNorm(
                     config.hidden_size,
@@ -970,7 +970,7 @@ class ParallelTransformerLayer(MegatronModule):
                     no_persist_layer_norm=not config.persist_layer_norm,
                     sequence_parallel=config.sequence_parallel,
                     apply_layernorm_1p=args.apply_layernorm_1p,
-                    mem_efficient_ln=args.mem_efficient_ln)
+                    mem_efficient_ln=not args.disable_mem_efficient_ln)
             else:
                 self.post_inter_attention_layernorm = MixedFusedRMSNorm(config.hidden_size, config.layernorm_epsilon)
 
@@ -1730,7 +1730,7 @@ class ParallelTransformer(MegatronModule):
                         no_persist_layer_norm=args.no_persist_layer_norm,
                         sequence_parallel=config.sequence_parallel,
                         apply_layernorm_1p=args.apply_layernorm_1p,
-                        mem_efficient_ln=args.mem_efficient_ln)
+                        mem_efficient_ln=not args.disable_mem_efficient_ln)
                 else:
                     self.final_layernorm = LayerNorm(
                         config.hidden_size,

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -919,7 +919,8 @@ class ParallelTransformerLayer(MegatronModule):
                     eps=config.layernorm_epsilon,
                     no_persist_layer_norm=args.no_persist_layer_norm,
                     sequence_parallel=config.sequence_parallel,
-                    apply_layernorm_1p=args.apply_layernorm_1p)
+                    apply_layernorm_1p=args.apply_layernorm_1p,
+                    mem_efficient_ln=args.mem_efficient_ln)
             else:
                 self.input_layernorm = LayerNorm(
                     config.hidden_size,
@@ -944,7 +945,8 @@ class ParallelTransformerLayer(MegatronModule):
                     eps=config.layernorm_epsilon,
                     no_persist_layer_norm=not config.persist_layer_norm,
                     sequence_parallel=config.sequence_parallel,
-                    apply_layernorm_1p=args.apply_layernorm_1p)
+                    apply_layernorm_1p=args.apply_layernorm_1p,
+                    mem_efficient_ln=args.mem_efficient_ln)
             else:
                 self.post_attention_layernorm = LayerNorm(
                     config.hidden_size,
@@ -967,7 +969,8 @@ class ParallelTransformerLayer(MegatronModule):
                     eps=config.layernorm_epsilon,
                     no_persist_layer_norm=not config.persist_layer_norm,
                     sequence_parallel=config.sequence_parallel,
-                    apply_layernorm_1p=args.apply_layernorm_1p)
+                    apply_layernorm_1p=args.apply_layernorm_1p,
+                    mem_efficient_ln=args.mem_efficient_ln)
             else:
                 self.post_inter_attention_layernorm = MixedFusedRMSNorm(config.hidden_size, config.layernorm_epsilon)
 
@@ -1726,7 +1729,8 @@ class ParallelTransformer(MegatronModule):
                         eps=config.layernorm_epsilon,
                         no_persist_layer_norm=args.no_persist_layer_norm,
                         sequence_parallel=config.sequence_parallel,
-                        apply_layernorm_1p=args.apply_layernorm_1p)
+                        apply_layernorm_1p=args.apply_layernorm_1p,
+                        mem_efficient_ln=args.mem_efficient_ln)
                 else:
                     self.final_layernorm = LayerNorm(
                         config.hidden_size,


### PR DESCRIPTION
Introduced in https://github.com/NVIDIA/apex/pull/1715

My PR lets the user disable this LayerNorm optimization, but I suspect everyone will use it so it's on-by-default.

Not backwards-compatible with older Apex. Do you need a version check or is this ok?