### PR TITLE
fix circular dependencies when using Lora

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -503,7 +503,7 @@ class ColumnParallelLinear(torch.nn.Module):
                  skip_bias_add=False,
                  skip_weight_param_allocation: bool=False,
                  moe=False, enable_expert_tensor_parallelism=False):
-        super(ColumnParallelLinear, self).__init__()
+        torch.nn.Module.__init__(self)
 
         # Keep input parameters
         self.input_size = input_size
@@ -691,7 +691,7 @@ class RowParallelLinear(torch.nn.Module):
                  keep_master_weight_for_test: bool = False,
                  skip_bias_add: bool = False,
                  moe=False, enable_expert_tensor_parallelism=False):
-        super(RowParallelLinear, self).__init__()
+        torch.nn.Module.__init__(self)
 
         # Keep input parameters
         self.input_size = input_size


### PR DESCRIPTION
Distributed layers such as ColumnParallelLinear use super for initialization, which will lead to circular dependencies when using Lora. Lora is initialized by passing the class name with self.