### PR TITLE
fix reshape for split qga

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -644,7 +644,7 @@ class ParallelAttention(MegatronModule):
                                      head_dim)
                                      
     def split_tensor(self, mixed_x_layer):
-        query_layer = mixed_x_layer[:, :, :, :-2, :].reshape(mixed_x_layer.shape[:-1] + (-1, self.hidden_size_per_attention_head))
+        query_layer = mixed_x_layer[:, :, :, :-2, :].reshape(mixed_x_layer.shape[:2] + (-1, self.hidden_size_per_attention_head))
         key_layer = mixed_x_layer[:, :, :, -2, :]
         value_layer = mixed_x_layer[:, :, :, -1, :]
 


### PR DESCRIPTION
The reshaping operation needs to transform the shape from **[sq, b, nkv, nq // nkv, hn]** to **[sq, b, -1, hn]**,instead of to **[sq, b, nkv, nq // nkv + 2, -1, hn]**