### PR TITLE
Fix deepspeed.zero.Init() call

### DIFF
--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -36,7 +36,7 @@ def model_provider(pre_process=True, post_process=True):
 
     args = get_args()
     config = core_transformer_config_from_args(args)
-    with deepspeed.zero.Init(sequence_data_parallel_group=mpu.get_sequence_data_parallel_group(),
+    with deepspeed.zero.Init(data_parallel_group=mpu.get_sequence_data_parallel_group(),
                              remote_device=None if args.remote_device == 'none' else args.remote_device,
                              config_dict_or_path=args.deepspeed_config,
                              enabled=args.zero_stage == 3,


### PR DESCRIPTION
This PR is required to fix the below error

Traceback (most recent call last):
  File "/myworkspace/Megatron-DeepSpeed/pretrain_gpt.py", line 351, in <module>
    pretrain(train_valid_test_datasets_provider,
  File "/myworkspace/Megatron-DeepSpeed/megatron/training.py", line 162, in pretrain
    model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
  File "/myworkspace/Megatron-DeepSpeed/megatron/training.py", line 524, in setup_model_and_optimizer
    model = get_model(model_provider_func, model_type)
  File "/myworkspace/Megatron-DeepSpeed/megatron/training.py", line 363, in get_model
    model = model_provider_func(
  File "/myworkspace/Megatron-DeepSpeed/pretrain_gpt.py", line 39, in model_provider
    with deepspeed.zero.Init(sequence_data_parallel_group=mpu.get_sequence_data_parallel_group(),
TypeError: __init__() got an unexpected keyword argument 'sequence_data_parallel_group'