### PR TITLE
[Bug_Fix]Modify the config of args.deepspeed_config to args.deepspeed_config_dict

### DIFF
--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -38,7 +38,7 @@ def model_provider(pre_process=True, post_process=True):
     config = core_transformer_config_from_args(args)
     with deepspeed.zero.Init(sequence_data_parallel_group=mpu.get_sequence_data_parallel_group(),
                              remote_device=None if args.remote_device == 'none' else args.remote_device,
-                             config_dict_or_path=args.deepspeed_config,
+                             config_dict_or_path=args.deepspeed_config_dict,
                              enabled=args.zero_stage == 3,
                              mpu=mpu):
         if args.deepspeed and not args.no_pipeline_parallel:


### PR DESCRIPTION
This pr is to fix the potential bug on init, according to the method _create_ds_config_dict() https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/training.py#L148, the flag args.deepspeed_config is set to None and the deepspeed_config is set to the args.deepspeed_config_dict, so in init the config_dict_or_path=None.
When we change to MiCS_Init it will cause error because the deepspeed_config is None, should set to args.deepspeed_config_dict.