### PR TITLE
Add a wandb logger

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -424,6 +424,10 @@ def validate_args(args, defaults={}):
         assert not args.mos, 'GQA currently does not support args.mos'
         assert not args.kd, 'GQA currently does not support args.kd'
 
+    if args.wandb_logger:
+        assert args.wandb_api_key is not None, "Must provide wandb_api_key when using wandb_logger"
+        assert args.wandb_entity is not None, "Must provide wandb_entity when using wandb_logger"
+    
     # Print arguments.
     _print_args("arguments", args)
     retro_args = get_retro_args()
@@ -716,6 +720,15 @@ def _add_logging_args(parser):
     group.add_argument('--log-world-size-to-tensorboard',
                        action='store_true',
                        help='Enable world size logging to tensorboard.')
+
+    # wandb logger arguments
+    group.add_argument("--wandb_logger", action="store_true", help="use the wandb logger")
+    group.add_argument("--wandb_project", type=str, default="megatron-ds-training")
+    group.add_argument("--wandb_entity", type=str, default=None)
+    group.add_argument("--wandb_api_key", type=str, default=None)
+    group.add_argument("--wandb_run_name", type=str, default=None)
+    group.add_argument("--wandb_resume", type=str, default=None)
+    group.add_argument("--wandb_id", type=str, default=None)
 
     return parser
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1228,10 +1228,13 @@ def _add_data_args(parser):
                                 'GPT2BPETokenizer',
                                 'SentencePieceTokenizer',
                                 'GPTSentencePieceTokenizer',
+                                'PretrainedFromHF',
                                 'NullTokenizer'],
                        help='What type of tokenizer to use.')
     group.add_argument('--tokenizer-model', type=str, default=None,
                        help='Sentencepiece tokenizer model.')
+    group.add_argument('--tokenizer-name-or-path', type=str, default=None,
+                          help='Pretrained tokenizer name or path')
     group.add_argument('--data-impl', type=str, default='infer',
                        choices=['mmap', 'infer'],
                        help='Implementation of indexed datasets.')

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -530,7 +530,7 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
     load_dir = getattr(args, load_arg)
 
     if args.deepspeed:
-        if args.finetune:
+        if args.finetune or args.task == "WIKITEXT103":
             loaded_dir, state_dict = model[0].load_checkpoint(load_dir,
                 load_module_strict=strict, load_optimizer_states=False,
                 load_lr_scheduler_states=False, load_module_only=True)

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -530,7 +530,7 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
     load_dir = getattr(args, load_arg)
 
     if args.deepspeed:
-        if args.finetune or args.task == "WIKITEXT103":
+        if args.finetune or ("task" in vars(args) and args.task == "WIKITEXT103"):
             loaded_dir, state_dict = model[0].load_checkpoint(load_dir,
                 load_module_strict=strict, load_optimizer_states=False,
                 load_lr_scheduler_states=False, load_module_only=True)

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -41,6 +41,13 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
 
     # Parse arguments
     args = parse_args(extra_args_provider, ignore_unknown_args)
+    # TODO: why can't these args be passed in?
+    args.wandb_logger = "True"
+    args.wandb_project = "test-logger"
+    args.wandb_entity = "nightingal3"
+    args.wandb_id = "testing-456"
+    args.wandb_resume = "None"
+    args.wandb_api_key = "b7a010df0c667b1672b227bd30fc7f16d3c1e0db"
 
     if args.use_checkpoint_args or args_defaults.get('use_checkpoint_args', False):
         assert args.load is not None, '--use-checkpoints-args requires --load argument'
@@ -51,7 +58,8 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
     # set global args, build tokenizer, and set adlr-autoresume,
     # tensorboard-writer, and timers.
     set_global_variables(args)
-
+    writer = get_tensorboard_writer()
+  
     # torch.distributed initialization
     def finish_mpu_init():
         args = get_args()
@@ -273,11 +281,12 @@ def _set_random_seed(seed_, data_parallel_random_init=False):
 def write_args_to_tensorboard():
     """Write arguments to tensorboard."""
     args = get_args()
-    writer = get_tensorboard_writer()
-    if writer:
-        for arg in vars(args):
-            writer.add_text(arg, str(getattr(args, arg)),
-                            global_step=args.iteration)
+    if not getattr(args,"wandb_logger",False):
+        writer = get_tensorboard_writer()
+        if writer:
+            for arg in vars(args):
+                writer.add_text(arg, str(getattr(args, arg)),
+                                global_step=args.iteration)
 
 
 def _initialize_mem_buffs():

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -41,13 +41,6 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
 
     # Parse arguments
     args = parse_args(extra_args_provider, ignore_unknown_args)
-    # TODO: why can't these args be passed in?
-    #args.wandb_logger = "True"
-    #args.wandb_project = "test-logger"
-    #args.wandb_entity = "nightingal3"
-    #args.wandb_id = "testing-456"
-    #args.wandb_resume = "None"
-    #args.wandb_api_key = "b7a010df0c667b1672b227bd30fc7f16d3c1e0db"
 
     if args.use_checkpoint_args or args_defaults.get('use_checkpoint_args', False):
         assert args.load is not None, '--use-checkpoints-args requires --load argument'

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -42,12 +42,12 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
     # Parse arguments
     args = parse_args(extra_args_provider, ignore_unknown_args)
     # TODO: why can't these args be passed in?
-    args.wandb_logger = "True"
-    args.wandb_project = "test-logger"
-    args.wandb_entity = "nightingal3"
-    args.wandb_id = "testing-456"
-    args.wandb_resume = "None"
-    args.wandb_api_key = "b7a010df0c667b1672b227bd30fc7f16d3c1e0db"
+    #args.wandb_logger = "True"
+    #args.wandb_project = "test-logger"
+    #args.wandb_entity = "nightingal3"
+    #args.wandb_id = "testing-456"
+    #args.wandb_resume = "None"
+    #args.wandb_api_key = "b7a010df0c667b1672b227bd30fc7f16d3c1e0db"
 
     if args.use_checkpoint_args or args_defaults.get('use_checkpoint_args', False):
         assert args.load is not None, '--use-checkpoints-args requires --load argument'

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -39,6 +39,21 @@ def build_tokenizer(args):
     elif args.tokenizer_type == 'NullTokenizer':
         assert args.vocab_size is not None
         tokenizer = _NullTokenizer(args.vocab_size)
+    elif args.tokenizer_type == "PretrainedFromHF":
+        assert args.tokenizer_name_or_path is not None
+
+        # prevent transformers from logging info and warnings on each rank
+        import transformers
+        import logging
+        if args.rank == 0:
+            transformers.utils.logging.set_verbosity(logging.INFO)
+        else:
+            # shut the warnings on replicas
+            transformers.utils.logging.set_verbosity(logging.ERROR)
+
+        if args.rank == 0:
+            print(" vocab file is un-used. loading tokenizer from pre-trained model")
+        tokenizer = _AutoTokenizer(args.tokenizer_name_or_path, vocab_extra_ids=args.vocab_extra_ids)
     else:
         raise NotImplementedError('{} tokenizer is not '
                                   'implemented.'.format(args.tokenizer_type))
@@ -534,3 +549,87 @@ class _NullTokenizer:
     @property
     def additional_special_tokens_ids(self):
         return None
+
+
+class _AutoTokenizer(AbstractTokenizer):
+    """AutoTokenizer for Hf Pretrained model loading."""
+
+    def __init__(self, tokenizer_name_or_path, vocab_extra_ids):
+        from transformers import AutoTokenizer
+        name = tokenizer_name_or_path
+        super().__init__(name)
+        hf_tokenizer_kwargs = {}
+        if vocab_extra_ids > 0:
+            # TODO @thomasw21 we might need to concatenate to a pre-existing list?
+            hf_tokenizer_kwargs["additional_special_tokens"] = [f"<extra_id_{_id}>" for _id in range(vocab_extra_ids)]
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, **hf_tokenizer_kwargs)
+        self.encoder = self.tokenizer.get_vocab()
+        self.decoder = {v: k for k, v in self.encoder.items()}
+
+    @property
+    def vocab_size(self):
+        return len(self.tokenizer) # vocab_size doesn't contain additional tokens
+
+    @property
+    def vocab(self):
+        # TODO @thomasw21 make sure that special tokens don't collapse with vocab tokens.
+        return {
+            **{special_token: self.tokenizer.convert_tokens_to_ids(special_token) for special_token in self.tokenizer.additional_special_tokens},
+            **self.tokenizer.vocab,
+        }
+
+    @property
+    def inv_vocab(self):
+        return {v: k for k, v in self.vocab.items()}
+
+    def tokenize(self, text):
+        return self.tokenizer.encode(text)
+
+    def detokenize(self, token_ids):
+        return self.tokenizer.decode(token_ids)
+
+    @property
+    def eod(self):
+        # TODO @thomasw21 might conflict with <eos>
+        return self.eos
+
+    @property
+    def cls(self):
+        candidate = self.tokenizer.cls_token_id
+        return self._check_token_candidate(candidate)
+
+    @property
+    def sep(self):
+        candidate = self.tokenizer.sep_token_id
+        return self._check_token_candidate(candidate)
+
+    @property
+    def pad(self):
+        candidate = self.tokenizer.pad_token_id
+        return self._check_token_candidate(candidate)
+
+    @property
+    def mask(self):
+        candidate = self.tokenizer.mask_token_id
+        return self._check_token_candidate(candidate)
+
+    @property
+    def bos(self):
+        raise NotImplementedError("Missing <bos>")
+
+    @property
+    def eos(self):
+        # TODO @thomasw21 might conflict with the notion of <eod>
+        candidate = self.tokenizer.eos_token_id
+        return self._check_token_candidate(candidate)
+
+    @property
+    def additional_special_tokens_ids(self):
+        """ All the additional special tokens you may want to use (list of strings)."""
+        return self.tokenizer.additional_special_tokens_ids
+
+    @staticmethod
+    def _check_token_candidate(candidate):
+        if candidate is None:
+            raise AttributeError("Token doesn't exist")
+        return candidate

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -48,6 +48,7 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.compression.compress import init_compression, redundancy_clean
 from deepspeed.runtime.data_pipeline.data_routing.helper import convert_to_random_ltd
 from megatron.model.transformer import ParallelTransformerLayer
+from deepspeed.runtime.config import DeepSpeedConfig
 
 def print_datetime(string):
     """Note that this call will sync across all ranks."""
@@ -116,8 +117,9 @@ def pretrain(train_valid_test_dataset_provider,
     timers = get_timers()
 
     if args.deepspeed:
-        args.deepspeed_configuration = json.load(
-            open(args.deepspeed_config, 'r', encoding='utf-8'))
+        # args.deepspeed_configuration = json.load(
+        #     open(args.deepspeed_config, 'r', encoding='utf-8'))
+        args.deepspeed_configuration = DeepSpeedConfig(args.deepspeed_config)._param_dict
         if "curriculum_learning" in args.deepspeed_configuration and \
             "enabled" in args.deepspeed_configuration["curriculum_learning"]:
             args.curriculum_learning_legacy = args.deepspeed_configuration[ \
@@ -459,9 +461,9 @@ def load_model_weights_only(model_provider_func):
     lr_scheduler = None
 
     if args.deepspeed:
-        with open(args.deepspeed_config, 'r') as fd:
-            ds_config = json.load(fd)
-
+        #with open(args.deepspeed_config, 'r') as fd:
+        #    ds_config = json.load(fd)
+        ds_config = DeepSpeedConfig(args.deepspeed_config)._params_dict
         # When loading just the model weights, ZeRO can be disabled.
         if 'zero_optimization' in ds_config:
             del ds_config['zero_optimization']

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -831,93 +831,93 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         timers.write(timers_to_log, writer, iteration,
                      normalizer=total_iterations)
     if writer and (iteration % args.tensorboard_log_interval == 0):
-        writer.add_scalar('steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples)
-        writer.add_scalar('steps-vs-samples/y=samples,x=steps', args.consumed_train_samples, iteration)
-        writer.add_scalar('steps-vs-tokens/y=steps,x=tokens', iteration, args.consumed_train_tokens)
-        writer.add_scalar('steps-vs-tokens/y=tokens,x=steps', args.consumed_train_tokens, iteration)
+        writer.add_scalar('sample/steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples)
+        writer.add_scalar('step/steps-vs-samples/y=samples,x=steps', args.consumed_train_samples, iteration)
+        writer.add_scalar('token/steps-vs-tokens/y=steps,x=tokens', iteration, args.consumed_train_tokens)
+        writer.add_scalar('step/steps-vs-tokens/y=tokens,x=steps', args.consumed_train_tokens, iteration)
         if args.log_learning_rate_to_tensorboard:
-            writer.add_scalar('learning-rate/learning-rate', learning_rate, iteration)
-            writer.add_scalar('learning-rate/learning-rate vs samples', learning_rate,
+            writer.add_scalar('step/learning-rate/learning-rate', learning_rate, iteration)
+            writer.add_scalar('sample/learning-rate/learning-rate vs samples', learning_rate,
                               args.consumed_train_samples)
-            writer.add_scalar('learning-rate/learning-rate vs tokens', learning_rate,
+            writer.add_scalar('token/learning-rate/learning-rate vs tokens', learning_rate,
                               args.consumed_train_tokens)
         if args.log_batch_size_to_tensorboard:
-            writer.add_scalar('batch-size/batch-size', batch_size, iteration)
-            writer.add_scalar('batch-size/batch-size vs samples', batch_size,
+            writer.add_scalar('step/batch-size/batch-size', batch_size, iteration)
+            writer.add_scalar('sample/batch-size/batch-size vs samples', batch_size,
                               args.consumed_train_samples)
-            writer.add_scalar('batch-size/batch-size vs tokens', batch_size,
+            writer.add_scalar('token/batch-size/batch-size vs tokens', batch_size,
                               args.consumed_train_tokens)
         for key in loss_dict:
-            writer.add_scalar(f"lm-loss-training/{key}", loss_dict[key], iteration)
-            writer.add_scalar(f"lm-loss-training/{key}" + ' vs samples', loss_dict[key],
+            writer.add_scalar(f"step/lm-loss-training/{key}", loss_dict[key], iteration)
+            writer.add_scalar(f"sample/lm-loss-training/{key}" + ' vs samples', loss_dict[key],
                               args.consumed_train_samples)
-            writer.add_scalar(f"lm-loss-training/{key}" + ' vs tokens', loss_dict[key],
+            writer.add_scalar(f"token/lm-loss-training/{key}" + ' vs tokens', loss_dict[key],
                               args.consumed_train_tokens)
         if args.log_loss_scale_to_tensorboard:
-            writer.add_scalar('loss-scale/loss-scale', loss_scale, iteration)
-            writer.add_scalar('loss-scale/loss-scale vs samples', loss_scale,
+            writer.add_scalar('step/loss-scale/loss-scale', loss_scale, iteration)
+            writer.add_scalar('sample/loss-scale/loss-scale vs samples', loss_scale,
                               args.consumed_train_samples)
-            writer.add_scalar('loss-scale/loss-scale vs tokens', loss_scale,
+            writer.add_scalar('token/loss-scale/loss-scale vs tokens', loss_scale,
                               args.consumed_train_tokens)
         if args.log_world_size_to_tensorboard:
-            writer.add_scalar('world-size/world-size', args.world_size, iteration)
-            writer.add_scalar('world-size/world-size vs samples', args.world_size,
+            writer.add_scalar('step/world-size/world-size', args.world_size, iteration)
+            writer.add_scalar('sample/world-size/world-size vs samples', args.world_size,
                               args.consumed_train_samples)
-            writer.add_scalar('world-size/world-size vs tokens', args.world_size,
+            writer.add_scalar('token/world-size/world-size vs tokens', args.world_size,
                               args.consumed_train_tokens)
         if grad_norm is not None:
-            writer.add_scalar('grad-norm/grad-norm', grad_norm, iteration)
-            writer.add_scalar('grad-norm/grad-norm vs samples', grad_norm,
+            writer.add_scalar('step/grad-norm/grad-norm', grad_norm, iteration)
+            writer.add_scalar('sample/grad-norm/grad-norm vs samples', grad_norm,
                               args.consumed_train_samples)
-            writer.add_scalar('grad-norm/grad-norm vs tokens', grad_norm,
+            writer.add_scalar('token/grad-norm/grad-norm vs tokens', grad_norm,
                               args.consumed_train_tokens)
         if num_zeros_in_grad is not None:
-            writer.add_scalar('num-zeros/num-zeros', num_zeros_in_grad, iteration)
-            writer.add_scalar('num-zeros/num-zeros vs samples', num_zeros_in_grad,
+            writer.add_scalar('step/num-zeros/num-zeros', num_zeros_in_grad, iteration)
+            writer.add_scalar('sample/num-zeros/num-zeros vs samples', num_zeros_in_grad,
                               args.consumed_train_samples)
-            writer.add_scalar('num-zeros/num-zeros vs tokens', num_zeros_in_grad,
+            writer.add_scalar('token/num-zeros/num-zeros vs tokens', num_zeros_in_grad,
                               args.consumed_train_tokens)
         if params_norm is not None:
-            writer.add_scalar('params-norm/params-norm', params_norm, iteration)
-            writer.add_scalar('params-norm/params-norm vs samples', params_norm,
+            writer.add_scalar('step/params-norm/params-norm', params_norm, iteration)
+            writer.add_scalar('sample/params-norm/params-norm vs samples', params_norm,
                               args.consumed_train_samples)
-            writer.add_scalar('params-norm/params-norm vs tokens', params_norm,
+            writer.add_scalar('token/params-norm/params-norm vs tokens', params_norm,
                               args.consumed_train_tokens)
         if hasattr(args, 'actual_seq_length'):
-            writer.add_scalar('seqlen/actual_seq_length', args.actual_seq_length,
+            writer.add_scalar('step/seqlen/actual_seq_length', args.actual_seq_length,
                               iteration)
-            writer.add_scalar('seqlen/actual_seq_length vs samples', args.actual_seq_length,
+            writer.add_scalar('sample/seqlen/actual_seq_length vs samples', args.actual_seq_length,
                               args.consumed_train_samples)
-            writer.add_scalar('seqlen/actual_seq_length vs tokens', args.actual_seq_length,
+            writer.add_scalar('token/seqlen/actual_seq_length vs tokens', args.actual_seq_length,
                               args.consumed_train_tokens)
         if args.curriculum_learning_legacy or args.data_efficiency_curriculum_learning:
-            writer.add_scalar('seqlen/curriculum_seqlen', args.curriculum_seqlen,
+            writer.add_scalar('step/seqlen/curriculum_seqlen', args.curriculum_seqlen,
                               iteration)
-            writer.add_scalar('seqlen/curriculum_seqlen vs samples', args.curriculum_seqlen,
+            writer.add_scalar('sample/seqlen/curriculum_seqlen vs samples', args.curriculum_seqlen,
                               args.consumed_train_samples)
-            writer.add_scalar('seqlen/curriculum_seqlen vs tokens', args.curriculum_seqlen,
+            writer.add_scalar('token/seqlen/curriculum_seqlen vs tokens', args.curriculum_seqlen,
                               args.consumed_train_tokens)
         if args.random_ltd:
-            writer.add_scalar('seqlen/random_ltd_reserved_length', args.random_ltd_reserved_length,
+            writer.add_scalar('step/seqlen/random_ltd_reserved_length', args.random_ltd_reserved_length,
                               iteration)
-            writer.add_scalar('seqlen/random_ltd_reserved_length vs samples', args.random_ltd_reserved_length,
+            writer.add_scalar('sample/seqlen/random_ltd_reserved_length vs samples', args.random_ltd_reserved_length,
                               args.consumed_train_samples)
-            writer.add_scalar('seqlen/random_ltd_reserved_length vs tokens', args.random_ltd_reserved_length,
+            writer.add_scalar('token/seqlen/random_ltd_reserved_length vs tokens', args.random_ltd_reserved_length,
                               args.consumed_train_tokens)
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
-                "mem-reserved-bytes",
+                "step/mem-reserved-bytes",
                 mem_stats["reserved_bytes.all.current"],
                 iteration,
             )
             writer.add_scalar(
-                "mem-allocated-bytes",
+                "sample/mem-allocated-bytes",
                 mem_stats["allocated_bytes.all.current"],
                 iteration,
             )
             writer.add_scalar(
-                "mem-allocated-count",
+                "token/mem-allocated-count",
                 mem_stats["allocation.all.current"],
                 iteration,
             )
@@ -967,31 +967,31 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
 
             # print('step {} rank {} after sync opt_stats {}, {}'.format(iteration, torch.distributed.get_rank(), opt_stats_2, opt_stats))
             if writer and is_last_rank():
-                writer.add_scalar('optimizer/variance_l2 vs tokens', opt_stats[0]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_sqrt_l2 vs tokens', opt_stats[1]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/momentum_l2 vs tokens', opt_stats[2]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/weight_l2 vs tokens', opt_stats[3]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_l1 vs tokens', opt_stats[4], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_sqrt_l1 vs tokens', opt_stats[5], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/momentum_l1 vs tokens', opt_stats[6], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/weight_l1 vs tokens', opt_stats[7], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_abs_max vs tokens', opt_stats_2[0], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_sqrt_abs_max vs tokens', opt_stats_2[1], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/momentum_abs_max vs tokens', opt_stats_2[2], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/weight_abs_max vs tokens', opt_stats_2[3], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/variance_l2 vs tokens', opt_stats[0]**0.5, args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/variance_sqrt_l2 vs tokens', opt_stats[1]**0.5, args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/momentum_l2 vs tokens', opt_stats[2]**0.5, args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/weight_l2 vs tokens', opt_stats[3]**0.5, args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/variance_l1 vs tokens', opt_stats[4], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/variance_sqrt_l1 vs tokens', opt_stats[5], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/momentum_l1 vs tokens', opt_stats[6], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/weight_l1 vs tokens', opt_stats[7], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/variance_abs_max vs tokens', opt_stats_2[0], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/variance_sqrt_abs_max vs tokens', opt_stats_2[1], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/momentum_abs_max vs tokens', opt_stats_2[2], args.consumed_train_tokens)
+                writer.add_scalar('token/optimizer/weight_abs_max vs tokens', opt_stats_2[3], args.consumed_train_tokens)
 
-                writer.add_scalar('optimizer/variance_l2', opt_stats[0]**0.5, iteration)
-                writer.add_scalar('optimizer/variance_sqrt_l2', opt_stats[1]**0.5, iteration)
-                writer.add_scalar('optimizer/momentum_l2', opt_stats[2]**0.5, iteration)
-                writer.add_scalar('optimizer/weight_l2', opt_stats[3]**0.5, iteration)
-                writer.add_scalar('optimizer/variance_l1', opt_stats[4], iteration)
-                writer.add_scalar('optimizer/variance_sqrt_l1', opt_stats[5], iteration)
-                writer.add_scalar('optimizer/momentum_l1', opt_stats[6], iteration)
-                writer.add_scalar('optimizer/weight_l1', opt_stats[7], iteration)
-                writer.add_scalar('optimizer/variance_abs_max', opt_stats_2[0], iteration)
-                writer.add_scalar('optimizer/variance_sqrt_abs_max', opt_stats_2[1], iteration)
-                writer.add_scalar('optimizer/momentum_abs_max', opt_stats_2[2], iteration)
-                writer.add_scalar('optimizer/weight_abs_max', opt_stats_2[3], iteration)
+                writer.add_scalar('step/optimizer/variance_l2', opt_stats[0]**0.5, iteration)
+                writer.add_scalar('step/optimizer/variance_sqrt_l2', opt_stats[1]**0.5, iteration)
+                writer.add_scalar('step/optimizer/momentum_l2', opt_stats[2]**0.5, iteration)
+                writer.add_scalar('step/optimizer/weight_l2', opt_stats[3]**0.5, iteration)
+                writer.add_scalar('step/optimizer/variance_l1', opt_stats[4], iteration)
+                writer.add_scalar('step/optimizer/variance_sqrt_l1', opt_stats[5], iteration)
+                writer.add_scalar('step/optimizer/momentum_l1', opt_stats[6], iteration)
+                writer.add_scalar('step/optimizer/weight_l1', opt_stats[7], iteration)
+                writer.add_scalar('step/optimizer/variance_abs_max', opt_stats_2[0], iteration)
+                writer.add_scalar('step/optimizer/variance_sqrt_abs_max', opt_stats_2[1], iteration)
+                writer.add_scalar('step/optimizer/momentum_abs_max', opt_stats_2[2], iteration)
+                writer.add_scalar('step/optimizer/weight_abs_max', opt_stats_2[3], iteration)
 
     if iteration % args.log_interval == 0:
         elapsed_time = timers('interval-time').elapsed(barrier=True)
@@ -1002,11 +1002,11 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         samples_per_sec, tflops, approx_parameters_in_billions = throughput_calculator(model, args, elapsed_time, total_iterations)
         if writer:
             if args.log_timers_to_tensorboard:
-                writer.add_scalar('iteration-time/iteration-time',
+                writer.add_scalar('step/iteration-time/iteration-time',
                                   elapsed_time_per_iteration, iteration)
-                writer.add_scalar('iteration-time/iteration-time vs samples',
+                writer.add_scalar('sample/iteration-time/iteration-time vs samples',
                                   elapsed_time_per_iteration, args.consumed_train_samples)
-                writer.add_scalar('iteration-time/iteration-time vs tokens',
+                writer.add_scalar('token/iteration-time/iteration-time vs tokens',
                                   elapsed_time_per_iteration, args.consumed_train_tokens)
         log_string = ' iteration {:8d}/{:8d} |'.format(
             iteration, args.train_iters)
@@ -1351,21 +1351,21 @@ def evaluate_and_print_results(prefix, forward_step_func,
         string += '{} PPL: {:.6E} | '.format(key, ppl)
         if writer and is_last_rank():
             data_type = 'test' if test else 'validation'
-            writer.add_scalar(f'lm-loss-validation/{key} {data_type}',
+            writer.add_scalar(f'step/lm-loss-validation/{key} {data_type}',
                               total_loss_dict[key].item(),
                               iteration)
-            writer.add_scalar(f'lm-loss-validation/{key} {data_type} vs samples',
+            writer.add_scalar(f'sample/lm-loss-validation/{key} {data_type} vs samples',
                               total_loss_dict[key].item(),
                               args.consumed_train_samples)
-            writer.add_scalar(f'lm-loss-validation/{key} {data_type} vs tokens',
+            writer.add_scalar(f'token/lm-loss-validation/{key} {data_type} vs tokens',
                               total_loss_dict[key].item(),
                               args.consumed_train_tokens)
             if args.log_validation_ppl_to_tensorboard:
-                writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl', ppl,
+                writer.add_scalar(f'step/lm-loss-validation/{key} {data_type} ppl', ppl,
                                   iteration)
-                writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs samples',
+                writer.add_scalar(f'sample/lm-loss-validation/{key} {data_type} ppl vs samples',
                                   ppl, args.consumed_train_samples)
-                writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs tokens',
+                writer.add_scalar(f'token/lm-loss-validation/{key} {data_type} ppl vs tokens',
                                   ppl, args.consumed_train_tokens)
 
     if process_non_loss_data_func is not None and writer and is_last_rank():

--- a/megatron/wandb_logger.py
+++ b/megatron/wandb_logger.py
@@ -1,0 +1,182 @@
+from dataclasses import dataclass,field
+from typing import Optional,List,Dict,Tuple, Union
+import torch
+from typing import Union
+import wandb
+from argparse import Namespace
+from collections import defaultdict
+import os
+from warnings import warn
+
+#TODO: do we want to use the watch? https://docs.wandb.ai/ref/python/watch
+@dataclass
+class WandBConfig(object):
+    # compatibility to previous logger
+    # config to be logged in wandb
+    config:Optional[Namespace]=field(default_factory=lambda :None)
+    # NOTE: these are ignored by wandb
+    # filled from `tensorboard_log_interval`, frequency of logging
+    log_interval:int=field(default=1)
+    # filled from `tensorboard_queue_size`, ignored by wandb
+    queue_size:int=field(default=int(1e3))
+    # if set, log locally into this dir, gets filled from tensorboard_dir
+    local_dir:Optional[str]=field(default=None)
+
+    # wandb specific config
+    # filled from args
+    #filled with kwargs
+    entity:str=field(default="meditron")
+    #wandb project to log to
+    project:str=field(default="meditron")
+    # save the code to the notebook?
+    save_code:bool=field(default=False)
+    # stuff to filter by
+    tags:Optional[List[str]]=field(default=None)
+    # short descriptive name to quickly find things
+    name:Optional[str]=field(default=None)
+    # long form notes and info to store
+    notes:Optional[str]=field(default=None)
+    # TODO: discuss how we want to do this, do we want to resume logging?
+    resume:str=field(default="allow")
+    # TODO: can fill this from the environment variable `WANDB_RUN_ID` ?
+    # globally unique id, if passed
+    run_id:Optional[str]=field(default=None)
+    # "magic" auto instrumentation, see https://docs.wandb.ai/ref/python/init
+    magic:bool=field(default=False)
+    api_key:Optional[str]=field(default=None)
+    with_tensorboard:bool=field(default=True)
+    try_catch_guard:bool=field(default=True)
+
+    @staticmethod
+    def default(project:str,run_id:str=run_id):
+        return WandBConfig(project=project,run_id=run_id)
+
+    @staticmethod
+    def from_args(args)->'WandBConfig':
+        assert args.rank==args.world_size-1, f"Only supposed to launch on rank {args.rank+1}, but got {args.rank}"
+        # following the megatron setup for now, could also do groups instead: https://docs.wandb.ai/guides/track/log/distributed-training
+        return WandBConfig(local_dir=args.tensorboard_dir,
+                           queue_size=args.tensorboard_queue_size,
+                           log_interval=args.log_interval,
+                           config=args,entity=args.wandb_entity,
+                           project=args.wandb_project,
+                           run_id=args.wandb_id,
+                           resume=args.wandb_resume,
+                           api_key=args.wandb_api_key,
+                           try_catch_guard=False,
+                           with_tensorboard=True)
+
+import functools
+# dummy_named just because of bare *
+def try_catch_guard(_func=None,*,dummy_named=None,**decorator_kwargs):
+    def decorator_try_catch_guard(func):
+        @functools.wraps(func)
+        def try_catch_wrapper(*args,**kwargs):
+            s=args[0]
+            if s.cfg.try_catch_guard:
+                try:
+                    return func(*args,**kwargs)
+                except BaseException as e:
+                    warn(f"Ignoring error {e} in WandbTBShim")
+            else:
+                return func(*args,**kwargs)
+        return try_catch_wrapper
+    if _func is None:
+        return decorator_try_catch_guard
+    else:
+        return decorator_try_catch_guard(_func)
+    
+
+class WandbTBShim(object):
+    """
+    Shim class that holds the configuration we want the wandb wrapper to use
+    (e.g. to control sampling, delay upload etc) and that translates the API
+    """
+    def __init__(self, config:WandBConfig):
+        super().__init__()
+        self.cfg=config
+        if os.environ.get("WANDB_API_KEY") is None:
+            if self.cfg.api_key is None:
+                raise ValueError("WANDB_API_KEY is not set, nor passed as an argument")
+            else:
+                os.environ["WANDB_API_KEY"]=self.cfg.api_key
+        wandb.init(config=config.config,
+                   entity=config.entity,
+                   project=config.project,
+                   save_code=config.save_code,
+                   tags=config.tags,
+                   name=config.name,
+                   notes=config.notes,
+                   resume=config.resume,
+                   id=config.run_id,
+                   dir=config.local_dir
+                )
+        self._last_step = None
+        self._log_accum = {}
+        if self.cfg.with_tensorboard:
+            try:
+                from torch.utils.tensorboard import SummaryWriter
+                print('> setting tensorboard ...')
+                self.tb_writer = SummaryWriter(
+                    log_dir=config.local_dir,
+                    max_queue=config.queue_size)
+            except ModuleNotFoundError:
+                print('WARNING: TensorBoard writing requested but is not '
+                      'available (are you using PyTorch 1.1.0 or later?), '
+                      'no TensorBoard logs will be written.', flush=True)
+        else:
+            self.tb_writer=None
+
+    @try_catch_guard
+    def _add_scalar(self, name: str, var: Union[float, int, torch.Tensor], step: int):
+        if isinstance(var, torch.Tensor):
+            var = var.item()
+        if self.tb_writer is not None:
+            self.tb_writer.add_scalar(name, var, global_step=step)
+        if " vs " in name:
+            # wandb does not allow logging to previous steps and the ' vs '
+            # scalars are usually a lot of steps forward compared to the rest
+            # of the scalars (as they count per sample, not per batch) so we
+            # just ignore them and rely on tensorboard to log them
+            warn(f"Ignoring wandb log for {name}")
+            return
+
+        if self._last_step is not None and step > self._last_step:
+            self.flush_all()
+
+        self._last_step = step
+        self._log_accum[name] = var
+
+    @try_catch_guard
+    def add_scalar(self, name: str, var: Union[float, int, torch.Tensor], step: int):
+        if isinstance(var, torch.Tensor):
+            var = var.item()
+        if self.tb_writer is not None:
+            self.tb_writer.add_scalar(name, var, global_step=step)
+        
+        wandb.log({name:var},step=step)
+
+    @try_catch_guard
+    def flush_all(self):
+        if len(self._log_accum) > 0:
+            wandb.log(self._log_accum, step=self._last_step, commit=True)
+        self._log_accum = {}
+        self._last_step = None
+
+    @try_catch_guard
+    def add_text(self,name:str,value:str):
+        # we log this on the creation of the wandb object, hence no need to log it here
+        if self.tb_writer is not None:
+            self.tb_writer.add_text(name,value)
+
+def toy_test(writer):
+    for i,l in zip(range(10),range(10,20)):
+        r=10-i
+        for k in range(5):
+            writer.add_scalar(f"forward{k}",l,i)
+            writer.add_scalar(f"backward{k}",r,i)
+            writer.add_scalar(f"forward{k} vs forward",l,i)
+            writer.add_scalar(f"forward{k} vs backward",i,r)
+if __name__=="__main__":
+    writer=WandbTBShim(WandBConfig.default("wandb-toy-test",run_id="meditron-wandb-test"))
+    toy_test(writer)

--- a/tasks/zeroshot_gpt/detokenizer.py
+++ b/tasks/zeroshot_gpt/detokenizer.py
@@ -65,3 +65,5 @@ def get_detokenizer(path):
     for key in _DETOKENIZERS.keys():
         if key in path:
             return _DETOKENIZERS[key]
+    # if no detokenizer is found, return identity function
+    return lambda x: x

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -190,13 +190,20 @@ def get_args():
                        help='Keep newlines between sentences when splitting.')
 
     group = parser.add_argument_group(title='tokenizer')
-    group.add_argument('--tokenizer-type', type=str, required=True,
-                       choices=['BertWordPieceLowerCase','BertWordPieceCase',
-                                'GPT2BPETokenizer', 'SentencePieceTokenizer',
-                                'GPTSentencePieceTokenizer', 'NullTokenizer'],
+    group.add_argument('--tokenizer-type', type=str,
+                       default=None,
+                       choices=['BertWordPieceLowerCase',
+                                'BertWordPieceCase',
+                                'GPT2BPETokenizer',
+                                'SentencePieceTokenizer',
+                                'GPTSentencePieceTokenizer',
+                                'PretrainedFromHF',
+                                'NullTokenizer'],
                        help='What type of tokenizer to use.')
     group.add_argument('--tokenizer-model', type=str, default=None,
-                       help='YTTM tokenizer model.')
+                       help='Sentencepiece tokenizer model.')
+    group.add_argument('--tokenizer-name-or-path', type=str, default=None,
+                          help='Pretrained tokenizer name or path')
     group.add_argument('--vocab-file', type=str, default=None,
                        help='Path to the vocab file')
     group.add_argument('--vocab-size', default=786,


### PR DESCRIPTION
We wanted to add a wandb logger to make it easier to share progress on runs. I noticed that [megatron-LLM already had one](https://github.com/epfLLM/Megatron-LLM/blob/1b06b129fa463b7bfce88ef49e2082f8df00c7fa/megatron/wandb_logger.py#L4) so I integrated it here (this is mostly just a port of that).

I haven't used tensorboard so I'm not sure if this interferes with logging there, let me know if it does.

**To test**: run the training script `pretrain_gpt.py` with any existing arguments. and add the arguments
```
    --wandb_logger \
    --wandb_entity <your wandb username> \
    --wandb_id <run_id> \
    --wandb_api_key <your wandb api key>
```

You should see a wandb run with a bunch of panels like `step/lm-loss-training` or `sample/steps-vs-samples
`
