### PR TITLE
Align variable before all_reduce with other files

### DIFF
--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -9,6 +9,7 @@ import time
 import numpy as np
 import torch
 
+from deepspeed.accelerator import get_accelerator
 from megatron import print_rank_0
 from megatron.core import mpu
 
@@ -79,7 +80,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                     cache_success = False
 
 
-            counts = torch.cuda.LongTensor([cache_success])
+            counts = get_accelerator().LongTensor([cache_success])
             torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
             torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
             if counts[0].item() != (


### PR DESCRIPTION
While in other files like: dataset_utils.py 726, biencoder_dataset_utils.py 191 etc this variable is created as get_accelerator().LongTensor in this file it was left as torch.cuda.LongTensor. This change is aligning those differences. 