### PR TITLE
fix a bug in `pretrain_bert.py`

### DIFF
--- a/pretrain_bert.py
+++ b/pretrain_bert.py
@@ -87,7 +87,7 @@ def data_post_process(data, data_sampler_state_dict):
     return data
 
 def loss_func(loss_mask, sentence_order, output_tensor):
-    lm_loss_, sop_logits = output_tensor
+    lm_loss_, sop_logits, _ = output_tensor
 
     lm_loss_ = lm_loss_.float()
     loss_mask = loss_mask.float()


### PR DESCRIPTION
fix a bug that cause
```bash
...
File "pretrain_bert.py", line 91, in loss_func
    lm_loss_, sop_logits = output_tensor
    ^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```
when using `examples_deepspeed/bert_with_pile/ds_pretrain_bert.sh`, `examples/pretrain_bert.sh` and `examples/pretrain_bert_distributed.sh`.

cuda 11.7, pytorch 2.0.1

`output_tensor` is like:
```bash
(tensor([[ 7.6910,  8.2171,  7.6419,  ...,  7.6605,  7.7664,  7.9584],
        [ 8.0546,  7.6694,  7.9774,  ...,  7.8288,  7.9537,  7.6055],
        [ 8.0042, 11.0503,  7.7699,  ...,  7.5501,  7.7662,  7.9076],
        [ 8.0456,  7.8315,  7.9037,  ...,  7.6657,  7.7722,  7.8742]],
       device='cuda:0', grad_fn=<CloneBackward0>), 
 tensor([[ 0.3318, -0.0834],
        [ 0.1063, -0.3003],
        [-0.2517, -0.0669],
        [ 0.1223,  0.1731]], device='cuda:0', grad_fn=<ToCopyBackward0>), 
 (tensor([[ 7.6910,  8.2171,  7.6419,  ...,  7.6605,  7.7664,  7.9584],
        [ 8.0546,  7.6694,  7.9774,  ...,  7.8288,  7.9537,  7.6055],
        [ 8.0042, 11.0503,  7.7699,  ...,  7.5501,  7.7662,  7.9076],
        [ 8.0456,  7.8315,  7.9037,  ...,  7.6657,  7.7722,  7.8742]],
       device='cuda:0', grad_fn=<CloneBackward0>), tensor([[ 0.3318, -0.0834],
        [ 0.1063, -0.3003],
        [-0.2517, -0.0669],
        [ 0.1223,  0.1731]], device='cuda:0', grad_fn=<ToCopyBackward0>))
)
```

Thanks for reviewing :-)