### PR TITLE
 Fix the error issue for DP on Megatron-DeepSpeed

### DIFF
--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -36,8 +36,8 @@ def model_provider(pre_process=True, post_process=True):
 
     args = get_args()
     config = core_transformer_config_from_args(args)
-    if hasattr(mpu, 'get_sequence_parallel_group'):
-        dpg = mpu.get_sequence_parallel_group()
+    if hasattr(mpu, 'get_sequence_data_parallel_group'):
+        dpg = mpu.get_sequence_data_parallel_group()
     elif hasattr(mpu, 'get_data_parallel_group'):
         dpg = mpu.get_data_parallel_group()
     else:


### PR DESCRIPTION
If sequence_data_parallel_group is 12 but sequence_parallel_group is 1, go the original path, the dp_process_group size is 1, then DP won't work on ZERO, that will cause memory and performance issue. 
For this pr https://github.com/microsoft/Megatron-DeepSpeed/pull/323, I think can be modified like this to fix this issue.