### PR TITLE
Support MoE for GPTModelPipe

### DIFF
--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -3,6 +3,7 @@
 """GPT-2 model."""
 
 import torch
+from collections import OrderedDict
 
 from megatron import get_args
 from megatron.core import mpu, tensor_parallel, sequence_parallel
@@ -456,3 +457,11 @@ class GPTModelPipe(PipelineModule,MegatronModule):
 
     def universal_checkpoint_info(self):
         return UniversalCheckpointInfo(using_model_pipe=True).get()
+
+    def get_additional_losses(self):
+        if not self.is_moe_model:
+            return None
+        return OrderedDict({
+            'lm loss': self.last_lm_loss,
+            'moe loss': self.last_moe_loss
+        })

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -361,13 +361,21 @@ class GPTModelPipe(PipelineModule,MegatronModule):
                                             tied_weight_attr='word_embeddings_weight'))
 
         experts_per_layer = get_num_experts_per_layer(args.num_experts, args.num_layers, args.expert_interval)
+        self.is_moe_model = any(n_experts > 1 for n_experts in experts_per_layer)
         for layer_idx in range(args.num_layers):
             self.specs.append(
                 LayerSpec(ParallelTransformerLayerPipe,
                           config,
                           layer_number=layer_idx,
                           self_attn_mask_type=AttnMaskType.causal,
-                          num_experts=experts_per_layer[layer_idx]))
+                          num_experts=experts_per_layer[layer_idx],
+                          input_aggregated_moe_loss=(self.is_moe_model and layer_idx > 0),
+                          return_aggregated_moe_loss=self.is_moe_model))
+
+        # if model has experts, add a layer to get and cache the aggregated moe loss from the
+        # last transformer layer
+        if self.is_moe_model:
+            self.specs.append(self._calculate_moe_loss)
 
         # Final layernorm after transformer layers
         if args.normalization == 'layernorm':
@@ -406,6 +414,11 @@ class GPTModelPipe(PipelineModule,MegatronModule):
         if args.fp16 or args.bf16:
             self.specs.append(float16_to_fp32)
 
+        # Cache losses
+        self.moe_loss = None
+        self.last_lm_loss = None    # detached, for display only
+        self.last_moe_loss = None   # detached, for display only
+
         if args.checkpoint_activations:
             interval = args.checkpoint_num_layers
         elif args.recompute_granularity == "full" and args.recompute_method == 'uniform':
@@ -420,10 +433,26 @@ class GPTModelPipe(PipelineModule,MegatronModule):
                                              num_dp=mpu.get_data_parallel_world_size())
 
         super().__init__(layers=self.specs,
-                         loss_fn=CrossEntropy,
+                         loss_fn=self.loss_func,
                          topology=topo,
                          activation_checkpoint_interval=interval,
                          partition_method='type:transformer')
+
+    def _calculate_moe_loss(self, inputs):
+        """ Calculate MoE auxiliary loss """
+        assert isinstance(inputs, tuple) and len(inputs) == 2
+        hidden, aggregated_moe_loss = inputs[0], inputs[1]
+        args = get_args()
+        self.moe_loss = aggregated_moe_loss * args.moe_loss_coeff
+        return hidden
+
+    def loss_func(self, output, labels):
+        loss = CrossEntropy(output, labels)
+        self.last_lm_loss = loss.clone().detach()
+        if self.moe_loss is not None:
+            loss += self.moe_loss
+            self.last_moe_loss = self.moe_loss.clone().detach()
+        return loss
 
     def universal_checkpoint_info(self):
         return UniversalCheckpointInfo(using_model_pipe=True).get()

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1208,7 +1208,8 @@ class ParallelTransformerLayer(MegatronModule):
                 retriever_output=None,
                 retriever_attn_mask=None,
                 inference_params=None,
-                rotary_pos_emb=None):
+                rotary_pos_emb=None,
+                aggregated_moe_loss=None):
         # hidden_states: [s, b, h]
 
         # Layer norm at the beginning of the transformer layer.
@@ -1300,6 +1301,10 @@ class ParallelTransformerLayer(MegatronModule):
         else:
             mlp_output, moe_loss, _ = self.mlp(layernorm_output)
 
+        # when aggregated_moe_loss received, returned moe_loss is the aggregated moe loss
+        if aggregated_moe_loss is not None:
+            moe_loss += aggregated_moe_loss
+
         # Second residual connection.
         if self.apply_residual_connection_post_layernorm:
             residual = layernorm_output
@@ -1360,23 +1365,51 @@ class ParallelTransformerLayerPipe(ParallelTransformerLayer):
        If no mask is provided, the module will query `self._args.attn_mask`
        for the mask and only return `super().forward(...)`
     """
+    def __init__(self, config,
+                 layer_number, layer_type=LayerType.encoder,
+                 self_attn_mask_type=AttnMaskType.padding,
+                 drop_path_rate=0., num_experts=1,
+                 input_aggregated_moe_loss=False, return_aggregated_moe_loss=False):
+        self.input_aggregated_moe_loss = input_aggregated_moe_loss
+        self.return_aggregated_moe_loss = return_aggregated_moe_loss
+        super().__init__(config, layer_number, layer_type, self_attn_mask_type, drop_path_rate, num_experts)
+
     def forward(self, inputs, **kwargs):
         assert torch.is_tensor(inputs) or isinstance(inputs, tuple)
         if not hasattr(self, '_args'):
             self._args = get_args()
         rotary_pos_emb = self._args.rotary_pos_emb if self._args.use_rotary_position_embeddings else None
         if torch.is_tensor(inputs) or len(inputs) == 1:
+            assert not self.input_aggregated_moe_loss, f'Expecting an input tuple of size >= 2'
             # No attention mask forwarded, search for args.attn_mask
             hidden_states, attention_mask = inputs, self._args.attn_mask
-            # HACK: currently MoE model does not support pipeline parallel, so
-            # here we just ignore the moe_loss returned by forward()
-            return super().forward(hidden_states, attention_mask, **kwargs, rotary_pos_emb=rotary_pos_emb)[0]
-        elif len(inputs) == 2:
-            # Attention mask is an activation.
-            hidden_states, attention_mask = inputs[0], inputs[1]
-            # HACK: currently MoE model does not support pipeline parallel, so
-            # here we just ignore the moe_loss returned by forward()
-            return super().forward(*inputs, **kwargs, rotary_pos_emb=rotary_pos_emb)[0], attention_mask
+            output, moe_loss = super().forward(hidden_states, attention_mask, **kwargs, rotary_pos_emb=rotary_pos_emb)
+            return (output, moe_loss) if self.return_aggregated_moe_loss else output
+        elif len(inputs) in (2, 3):
+            # Attention mask and aggregated_moe can both be activations.
+            return_attention_mask = False
+            if len(inputs) == 2:
+                if self.input_aggregated_moe_loss:
+                    hidden_states, aggregated_moe_loss = inputs[0], inputs[1]
+                    attention_mask = self._args.attn_mask
+                else:
+                    hidden_states, attention_mask = inputs[0], inputs[1]
+                    return_attention_mask = True
+            else:
+                hidden_states, attention_mask, aggregated_moe_loss = inputs[0], inputs[1], inputs[2]
+
+            # Forward aggregated_moe_loss to ParallelTransformerLayer for further accumulation
+            if self.input_aggregated_moe_loss:
+                kwargs.update({'aggregated_moe_loss': aggregated_moe_loss})
+
+            output, moe_loss = super().forward(hidden_states, attention_mask, **kwargs, rotary_pos_emb=rotary_pos_emb)
+
+            ret = (output, )
+            if return_attention_mask:
+                ret += (attention_mask, )
+            if self.return_aggregated_moe_loss:
+                ret += (moe_loss, )
+            return ret
         else:
             raise RuntimeError('Received more inputs than understood.')
 


### PR DESCRIPTION
Main changes:
- Support MoE layers creation.
- Support MoE aux loss for GPTModelPipe by propagating the aux loss along the layers.
- Support display of MoE aux loss.

**NOTE that this PR is dependent on DeepSpeed PR#5338 [https://github.com/microsoft/DeepSpeed/pull/5338](url)<br>**

Below are tensorboard captures of tests to verify MoE support for pipeline and test no regressions.
Testing was done with following configurations:
- Dense model: LLaMA like model with 8 layers.
- MoE modles: Dense with --num-experts 4 --topk 2 --disable-moe-token-dropping --expert-interval 1

Training runs **with** and **without this PR**:
1. GPTModel Dense (No MoE) using DP, TP with fp16
2. GPTModelPipe Dense (No MoE) using DP, TP, PP with BF16_Optimizer
3. GPTModel MoE using DP, TP, EP with fp16
4. GPTModelPipe MoE using DP, TP, PP, EP with BF16_Optimizer (only with this PR)


Training loss curve of a GPTModel model with fp16, No MOE (i.e. Dense network).
Scaling: 8xA100 DP=4 TP=2 PP=1, ZERO=0, Using GPTModel
Comparing without vs with this PR.
 ![GPTModel_2D_Dense_fp16_with_vs_without_PR](https://github.com/microsoft/Megatron-DeepSpeed/assets/26796709/685f9ed5-83f0-40a4-9986-721c1ea09d66)


Training loss curve of GPTModel model with fp16, with MOE (4 experts, top2).
Scaling: 8xA100 DP=4 TP=2 PP=1, ZERO=0, Using GPTModel
Comparing without vs with this PR.
![GPTModel_2D_MoE_fp16_with_vs_without_PR](https://github.com/microsoft/Megatron-DeepSpeed/assets/26796709/1bf2ea3c-a890-459d-a435-0b39deb16c90)

Training loss curve of a GPTModelPipe model with BF16_Optimizer, No MOE (i.e. Dense network).
Scaling: 8xA100 DP=2 TP=2 PP=2, ZERO=0, Using GPTModelPipe
Comparing without vs with this PR
![GPTModelPipe_3D_Dense_bf16_with_vs_without_PR](https://github.com/microsoft/Megatron-DeepSpeed/assets/26796709/054ade22-debc-4e61-9dbf-097749677949)

Comparing using with this PR:
- GPTModel         DP=4 TP=2 PP=1 fp16 
- GPTModelPipe DP=2 TP=2 PP=2 BF16_Optimizer

At the beginning of the training, GPTModel fp16 is a little behind due to few steps of loss-scale adjustments. However, both configurations end up with very close loss.
![GPTModel_fp16_vs_GPTModelPipePipe_bf16_MOE](https://github.com/microsoft/Megatron-DeepSpeed/assets/26796709/91388909-526c-417d-ae14-ad4a0232194c)


