### PR TITLE
Fix ConstantGradScaler and loss-scale argument not match

### DIFF
--- a/megatron/optimizer/grad_scaler.py
+++ b/megatron/optimizer/grad_scaler.py
@@ -39,6 +39,9 @@ class MegatronGradScaler(ABC):
 
 class ConstantGradScaler(MegatronGradScaler):
 
+    def __init__(self, initial_scale_power):
+        super().__init__(2**initial_scale_power)
+
     def update(self, found_inf):
         pass
 


### PR DESCRIPTION
 The usage and description of `loss-scale` is inconsistent. The argument of `loss-scale` expect to get a number of positive power of 2 but `ConstantGradScaler` set loss-scale as real scale directly.

Argument Description:
<img width="626" alt="image" src="https://github.com/microsoft/Megatron-DeepSpeed/assets/31957460/ddf14f5e-995a-41a5-9616-67f5ce1f7488">

Argument Usage:
<img width="642" alt="image" src="https://github.com/microsoft/Megatron-DeepSpeed/assets/31957460/5baaffb8-ac51-4668-8bbe-86b1236a9083">
