### PR TITLE
ds-sequence-parallel(ulysses)  for rope.

### DIFF
--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -543,6 +543,10 @@ class TransformerLanguageModel(MegatronModule):
             else:
                 if args.curriculum_learning_legacy or args.data_efficiency_curriculum_learning:
                     rotary_pos_emb = self.rotary_pos_emb(args.curriculum_seqlen)
+                elif args.ds_sequence_parallel_size > 1:
+                   parallel_seq_len = self.seq_length / args.ds_sequence_parallel_size
+                   ds_sp_offset =  mpu.get_sequence_parallel_rank() * parallel_seq_len
+                   rotary_pos_emb = self.rotary_pos_emb(parallel_seq_len, ds_sp_offset)
                 else:
                     rotary_pos_emb = self.rotary_pos_emb(self.seq_length)
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -401,10 +401,6 @@ class FlashSelfAttention(torch.nn.Module):
         ---------
             q, k, v: The tensor containing the query, key, and value. (B, S, H, D)
         """
-        # dump q, k, v tensor after by heads
-        heads_per_gpus = q.shape[2]
-        for hid in range(heads_per_gpus):
-            print(f"heads_{hid+mpu.get_sequence_parallel_rank()*heads_per_gpus} : {q[:,:,hid,:],k[:,:,hid,:],v[:,:,hid,:]}")
 
         assert all((i.dtype in [torch.float16, torch.bfloat16] for i in (q,k,v)))
         assert all((get_accelerator().on_accelerator(i) for i in (q, k, v)))

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -401,6 +401,10 @@ class FlashSelfAttention(torch.nn.Module):
         ---------
             q, k, v: The tensor containing the query, key, and value. (B, S, H, D)
         """
+        # dump q, k, v tensor after by heads
+        heads_per_gpus = q.shape[2]
+        for hid in range(heads_per_gpus):
+            print(f"heads_{hid+mpu.get_sequence_parallel_rank()*heads_per_gpus} : {q[:,:,hid,:],k[:,:,hid,:],v[:,:,hid,:]}")
 
         assert all((i.dtype in [torch.float16, torch.bfloat16] for i in (q,k,v)))
         assert all((get_accelerator().on_accelerator(i) for i in (q, k, v)))


### PR DESCRIPTION
get & calcuate repo by sequence parallel.

with test config
- sp=1, gpus=1, apply rope
- sp=2, gpus=2, apply rope

When performing head parallelism in all-to-all, I dumped the Q, K, and V values and obtained identical results in both experiments.  dump code can be found at  https://github.com/microsoft/Megatron-DeepSpeed/commit/eedfe9c7d374327bf21f29c1c12b5cbf625941e1
