### PR TITLE
Convert to iteration based training supported by pretraining scripts

### DIFF
--- a/examples_deepspeed/MoE/ds_pretrain_gpt_125M_dense_cl.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_125M_dense_cl.sh
@@ -94,7 +94,7 @@ TRAIN_TOKENS=300000000000
 ## above, and techniques like curriculum learning has less token in some samples,
 ## so we just set this config large enough to make sure we have enough
 ## processed data and don't terminate by TRAIN_SAMPLES.
-TRAIN_SAMPLES=$(( ${TRAIN_TOKENS} * 3 / ${SEQ_LEN} ))
+TRAIN_ITERS=$(( ${TRAIN_TOKENS} * 3 / ${GLOBAL_BATCH_SIZE} / ${SEQ_LEN} ))
 
 ## Another termination condition in minutes. Set it large enough to avoid
 ## undesired early termination.
@@ -206,7 +206,7 @@ megatron_options=" \
         --seq-length ${SEQ_LEN} \
         --max-position-embeddings ${SEQ_LEN} \
         --train-tokens ${TRAIN_TOKENS} \
-        --train-samples ${TRAIN_SAMPLES} \
+        --train-iters ${TRAIN_ITERS} \
         --lr ${LR} \
         --min-lr ${MIN_LR} \
         --lr-decay-style cosine \


### PR DESCRIPTION
Some scripts in the `Megatron-DeepSpeed/examples_deepspeed/MoE` folder are not runnable by default due to misconfigurations in the bash script. For instance, the `ds_pretrain_gpt_125M_dense_cl.sh` script is set to use sample-based training but the `pretrain_gpt.py` only supports iteration-based training. So I just changed the config file to make it compatible by converting it to use a iteration-based training schedule.

There are a bunch of other issues with the examples and I've observed a bit of a mismatch between the [tutorials](https://www.deepspeed.ai/tutorials/)  and the actual code linked from it. Since I'm working on Megatron-Deepseed these days, I'd like to keep making a log and hopefully propose some changes to improve the usability of this amazing framework.