### PR TITLE
update universal_checkpointing/README.md

### DIFF
--- a/examples_deepspeed/universal_checkpointing/README.md
+++ b/examples_deepspeed/universal_checkpointing/README.md
@@ -77,6 +77,8 @@ Please see the corresponding [pull request](https://github.com/microsoft/Megatro
 
 Combining sequence parallelism with data parallelism is another good use case for universal checkpointing, see [sp pull request](https://github.com/microsoft/DeepSpeed/pull/4752) for example and visualization of matching loss values.
 
+Notes: The model weights using the ```--no-pipeline-parallel``` parameter and the model weights not using the ```--no-pipeline-parallel``` parameter are currently not supported for mutual conversion.
+
 ### TensorBoard Log Analysis
 
 The Universal Checkpointing example includes a TensorBoard analysis script that will generate `csv` files and `png` plots across the unviersal checkpointing training steps for comparison of training and validation loss curves.


### PR DESCRIPTION
Is my understanding correct？ due to compatibility with PP, for example, when using ds-SP, it needs to be disabled, which means some weights that previously relied on PP cannot be directly used.