### PR TITLE
fix NAN loss of rope long context training

### DIFF
--- a/megatron/model/rotary_pos_embedding.py
+++ b/megatron/model/rotary_pos_embedding.py
@@ -20,8 +20,9 @@ class RotaryEmbedding(nn.Module):
             raise RuntimeError("einops is required for Rotary Embedding")
 
     def forward(self, max_seq_len, offset=0):
-        seq = torch.arange(max_seq_len, device=self.inv_freq.device) + offset
-        freqs = einsum('i , j -> i j', seq.type_as(self.inv_freq), self.inv_freq)
+        seq = torch.arange(max_seq_len, device=self.inv_freq.device, dtype=torch.float) + offset
+        # Force float32 since bfloat16 loses precision on long contexts
+        freqs = einsum('i , j -> i j', seq, self.inv_freq.float())
         # first part even vector components, second part odd vector components,
         #  2 * dim in dimension size
         emb = torch.cat((freqs, freqs), dim=-1)


### PR DESCRIPTION
 based on ( https://github.com/microsoft/Megatron-DeepSpeed/pull/392) , we get NAN loss with long centext trainging by ds-sp(ulysses) of llama style model.

We found that this issue is caused by precision problems. Half precision of rope sequence representation leads to loss in long context. Similar modifications alos have been applied to the transformers.  
https://github.com/huggingface/transformers/blob/63fb253df0d976b95d9b4b9a7b0012e5f8a37896/src/transformers/models/llama/modeling_llama.py#L111
