### PR TITLE
Set proper arguments when constructing models in unit tests

### DIFF
--- a/tests/models/test_gpt_embedding.py
+++ b/tests/models/test_gpt_embedding.py
@@ -3,15 +3,19 @@
 import pytest
 
 import torch
+import types
 
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.models.gpt.gpt_embedding import GPTEmbedding
+from megatron.global_vars import set_args
 
 from deepspeed.accelerator import get_accelerator
 device_name = get_accelerator().device_name()
 
 @pytest.fixture
 def gpt_embedding(transformer_config):
+    args = types.SimpleNamespace(params_dtype=torch.float32, embed_layernorm=False)
+    set_args(args)
     embedding = GPTEmbedding(config=transformer_config, vocab_size=100, max_sequence_length=4)
     return embedding
 

--- a/tests/transformer/test_parallel_mlp.py
+++ b/tests/transformer/test_parallel_mlp.py
@@ -3,14 +3,27 @@
 import pytest
 
 import torch
+import types
 
 from megatron.core.transformer.parallel_mlp import ParallelMLP
+from megatron.global_vars import set_args
 
 from deepspeed.accelerator import get_accelerator
 device_name = get_accelerator().device_name()
 
 @pytest.fixture
 def mlp(transformer_config):
+    mlp_args = types.SimpleNamespace(
+        swiglu=False,
+        openai_gelu=True,
+        onnx_safe=False,
+        bias_gelu_fusion=False,
+        transformer_impl="",
+        cache_fp8_weight=False,
+        fp8_interval=False,
+        cache_fp8_weight_fwd=False
+    )
+    set_args(mlp_args)
     return ParallelMLP(transformer_config)
 
 


### PR DESCRIPTION
when contructing models in unit test, arguments need to be set. Take `ParallelMLP()` as an example, `get_args()` is used to get some args setted by user in the constructor func:
https://github.com/microsoft/Megatron-DeepSpeed/blob/ea4b67a2bb5e572bdbe9c4fd3aa0e539e8e17110/megatron/model/transformer.py#L99-L101
So, need to `set_args()` accordingly.