### PR TITLE
[Wandb] Refine wandb logging function

### DIFF
--- a/examples_deepspeed/pretrain_llama2_distributed.sh
+++ b/examples_deepspeed/pretrain_llama2_distributed.sh
@@ -41,6 +41,15 @@ GRAD_CLIP=1
 # activation_checkpoint="true"
 activation_checkpoint="false"
 
+LOG_TO_WANDB=0
+WANDB_ARGS=
+if [ $LOG_TO_WANDB -eq 1 ]
+then
+WANDB_ARGS="\
+       --wandb-project pretrain-llama2 \
+       --wandb-exp-name exp0"
+fi
+
 # Below configuration required for llama model as per llama paper
 # --no-query-key-layer-scaling \
 # --attention-dropout 0 \
@@ -51,7 +60,6 @@ activation_checkpoint="false"
 # --normalization rmsnorm \
 # --disable-bias-linear \
 ######################################
-
 
 
 cat <<EOT > $DS_CONFIG
@@ -132,4 +140,5 @@ torchrun $DISTRIBUTED_ARGS \
        --normalization rmsnorm \
        --disable-bias-linear \
        --num-key-value-heads $NUM_KV_HEADS \
+       $WANDB_ARGS \
        $ds_args

--- a/examples_deepspeed/pretrain_llama2_distributed.sh
+++ b/examples_deepspeed/pretrain_llama2_distributed.sh
@@ -47,7 +47,9 @@ if [ $LOG_TO_WANDB -eq 1 ]
 then
 WANDB_ARGS="\
        --wandb-project pretrain-llama2 \
-       --wandb-exp-name exp0"
+       --wandb-exp-name exp0 \
+       --wandb-save-dir ${BASE_PATH}/wandb \
+       "
 fi
 
 # Below configuration required for llama model as per llama paper

--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -9,6 +9,7 @@ from .global_vars import get_signal_handler
 from .global_vars import update_num_microbatches
 from .global_vars import get_tokenizer
 from .global_vars import get_tensorboard_writer
+from .global_vars import get_wandb_writer
 from .global_vars import get_adlr_autoresume
 from .global_vars import get_timers
 from .initialize  import initialize_megatron

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -746,6 +746,10 @@ def _add_logging_args(parser):
     group.add_argument('--log-world-size-to-tensorboard',
                        action='store_true',
                        help='Enable world size logging to tensorboard.')
+    group.add_argument('--wandb-project', type=str, default='',
+                       help='The wandb project name. Ignore wandb by default.')
+    group.add_argument('--wandb-exp-name', type=str, default='',
+                       help='The wandb experiment name.')
 
     return parser
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -750,6 +750,8 @@ def _add_logging_args(parser):
                        help='The wandb project name. Ignore wandb by default.')
     group.add_argument('--wandb-exp-name', type=str, default='',
                        help='The wandb experiment name.')
+    group.add_argument('--wandb-save-dir', type=str, default='',
+                       help='Path to save the wandb results locally.')
 
     return parser
 

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -184,9 +184,13 @@ def _set_wandb_writer(args):
                   'no WANDB logs will be written.', flush=True)
             return
 
-        # Update the wandb save_dir
+        if args.wandb_save_dir:
+            save_dir = args.wandb_save_dir
+        else:
+            # Defaults to the save dir.
+            save_dir = os.path.join(args.save, 'wandb')
         wandb_kwargs = {
-            'dir': os.path.join(args.save, 'wandb'),
+            'dir': save_dir,
             'name': args.wandb_exp_name,
             'project': args.wandb_project,
             'config': vars(args)}

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -165,12 +165,16 @@ def _set_wandb_writer(args):
     global _GLOBAL_WANDB_WRITER
     _ensure_var_is_not_initialized(_GLOBAL_WANDB_WRITER,
                                    'wandb writer')
-    if getattr(args, 'wandb_project', '') and \
-        args.rank == (args.world_size - 1):
-        if args.wandb_exp_name == '':
+    getattr(args, 'wandb_project', '')
+    getattr(args, 'wandb_exp_name', '')
+
+    if args.rank == (args.world_size - 1):
+        if args.wandb_project == '' or \
+            args.wandb_exp_name == '':
             print('WARNING: WANDB writing requested but no legit wandb '
-                  'experiment name is provided, '
-                  'no WANDB logs will be written.', flush=True)
+                  'project or experiment name provided, '
+                  'therefore WANDB logs will be written '
+                  'according to random generated project or experiment name.', flush=True)
 
         try:
             import wandb
@@ -178,6 +182,7 @@ def _set_wandb_writer(args):
             print('WARNING: WANDB writing requested but is not '
                   'available (try to pip install wandb to solve it), '
                   'no WANDB logs will be written.', flush=True)
+            return
 
         # Update the wandb save_dir
         wandb_kwargs = {

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -16,6 +16,7 @@ _GLOBAL_RETRO_ARGS = None
 _GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
 _GLOBAL_TOKENIZER = None
 _GLOBAL_TENSORBOARD_WRITER = None
+_GLOBAL_WANDB_WRITER = None
 _GLOBAL_ADLR_AUTORESUME = None
 _GLOBAL_TIMERS = None
 _GLOBAL_SIGNAL_HANDLER = None
@@ -56,6 +57,12 @@ def get_tensorboard_writer():
     return _GLOBAL_TENSORBOARD_WRITER
 
 
+def get_wandb_writer():
+    """Return wandb writer. It can be None so no need
+    to check if it is initialized."""
+    return _GLOBAL_WANDB_WRITER
+
+
 def get_adlr_autoresume():
     """ADLR autoresume object. It can be None so no need
     to check if it is initialized."""
@@ -91,6 +98,7 @@ def set_global_variables(args):
     _build_num_microbatches_calculator(args)
     _ = _build_tokenizer(args)
     _set_tensorboard_writer(args)
+    _set_wandb_writer(args)
     _set_adlr_autoresume(args)
     _set_timers(args)
 
@@ -150,6 +158,36 @@ def _set_tensorboard_writer(args):
             print('WARNING: TensorBoard writing requested but is not '
                   'available (are you using PyTorch 1.1.0 or later?), '
                   'no TensorBoard logs will be written.', flush=True)
+
+
+def _set_wandb_writer(args):
+    """Set wandb writer."""
+    global _GLOBAL_WANDB_WRITER
+    _ensure_var_is_not_initialized(_GLOBAL_WANDB_WRITER,
+                                   'wandb writer')
+    if getattr(args, 'wandb_project', '') and \
+        args.rank == (args.world_size - 1):
+        if args.wandb_exp_name == '':
+            print('WARNING: WANDB writing requested but no legit wandb '
+                  'experiment name is provided, '
+                  'no WANDB logs will be written.', flush=True)
+
+        try:
+            import wandb
+        except (ImportError, ModuleNotFoundError):
+            print('WARNING: WANDB writing requested but is not '
+                  'available (try to pip install wandb to solve it), '
+                  'no WANDB logs will be written.', flush=True)
+
+        # Update the wandb save_dir
+        wandb_kwargs = {
+            'dir': os.path.join(args.save, 'wandb'),
+            'name': args.wandb_exp_name,
+            'project': args.wandb_project,
+            'config': vars(args)}
+        os.makedirs(wandb_kwargs['dir'], exist_ok=True)
+        wandb.init(**wandb_kwargs)
+        _GLOBAL_WANDB_WRITER = wandb
 
 
 def _set_adlr_autoresume(args):

--- a/megatron/timers.py
+++ b/megatron/timers.py
@@ -303,7 +303,7 @@ class Timers:
         assert normalizer > 0.0
         name_to_min_max_time = self._get_global_min_max_time(
             names, reset, barrier, normalizer)
-        if writer is not None:
+        if writer.is_enabled():
             for name in name_to_min_max_time:
                 _, max_time = name_to_min_max_time[name]
-                writer.add_scalar(name + '-time', max_time, iteration)
+                writer.add_scalar_to_tb(name + '-time', max_time, iteration)

--- a/megatron/timers.py
+++ b/megatron/timers.py
@@ -306,4 +306,4 @@ class Timers:
         if writer.is_enabled():
             for name in name_to_min_max_time:
                 _, max_time = name_to_min_max_time[name]
-                writer.add_scalar_to_tb(name + '-time', max_time, iteration)
+                writer.add_scalar(name + '-time', max_time, iteration)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -17,6 +17,7 @@ from megatron import get_args
 from megatron import get_signal_handler
 from megatron import get_timers
 from megatron import get_tensorboard_writer
+from megatron import get_wandb_writer
 from megatron import get_current_global_batch_size
 from megatron import get_num_microbatches
 from megatron import is_last_rank
@@ -51,12 +52,6 @@ from deepspeed.runtime.data_pipeline.data_routing.helper import convert_to_rando
 from megatron.model.transformer import ParallelTransformerLayer
 
 from deepspeed import comm as dist
-
-try:
-    import wandb
-except (ImportError, ModuleNotFoundError):
-    wandb = None
-
 
 def print_datetime(string):
     """Note that this call will sync across all ranks."""
@@ -785,6 +780,37 @@ def train_step(forward_step_func, data_iterator,
     return {}, skipped_iter, grad_norm, num_zeros_in_grad
 
 
+class interop_tool_logger:
+    def __init__(self, tb_writer=None, wandb_writer=None):
+        self.tb_writer = tb_writer
+        self.wandb_writer = wandb_writer
+
+    def is_enabled(self):
+        return self.tb_writer or self.wandb_writer
+
+    def add_scalar(self, key, scalar_value, step=None, tool_type='all'):
+        # tool_type is in ['all', 'wandb', 'tb']
+        if self.tb_writer and tool_type != 'wandb':
+            self.tb_writer.add_scalar(key, scalar_value, step)
+
+        if self.wandb_writer and tool_type != 'tb':
+            self.wandb_writer.log({key: scalar_value}, step)
+
+    def add_scalar_to_tb(self, key, scalar_value, step=None):
+        return self.add_scalar(key, scalar_value, step, tool_type='tb')
+
+    def add_scalar_to_wandb(self, key, scalar_value, step=None):
+        return self.add_scalar(key, scalar_value, step, tool_type='wandb')
+
+    def add_images(self, key, img_tensor, step=None):
+        if self.tb_writer:
+            self.tb_writer.add_images(key, img_tensor, step)
+
+        if self.wandb_writer:
+            import wandb
+            self.wandb_writer.log({key: wandb.Image(img_tensor)}, step)
+
+
 def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                  loss_scale, report_memory_flag, skipped_iter,
                  grad_norm, params_norm, num_zeros_in_grad,
@@ -792,7 +818,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     """Log training information such as losses, timing, ...."""
     args = get_args()
     timers = get_timers()
-    writer = get_tensorboard_writer()
+    writer = interop_tool_logger(tb_writer=get_tensorboard_writer(), \
+                                 wandb_writer=get_wandb_writer())
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = 'advanced iterations'
@@ -864,79 +891,79 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
        (iteration % args.tensorboard_log_interval == 0):
         timers.write(timers_to_log, writer, iteration,
                      normalizer=total_iterations)
-    if writer and (iteration % args.tensorboard_log_interval == 0):
-        writer.add_scalar('steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples)
+    if writer.is_enabled() and (iteration % args.tensorboard_log_interval == 0):
+        writer.add_scalar_to_tb('steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples)
         writer.add_scalar('steps-vs-samples/y=samples,x=steps', args.consumed_train_samples, iteration)
-        writer.add_scalar('steps-vs-tokens/y=steps,x=tokens', iteration, args.consumed_train_tokens)
+        writer.add_scalar_to_tb('steps-vs-tokens/y=steps,x=tokens', iteration, args.consumed_train_tokens)
         writer.add_scalar('steps-vs-tokens/y=tokens,x=steps', args.consumed_train_tokens, iteration)
         if args.log_learning_rate_to_tensorboard:
             writer.add_scalar('learning-rate/learning-rate', learning_rate, iteration)
-            writer.add_scalar('learning-rate/learning-rate vs samples', learning_rate,
+            writer.add_scalar_to_tb('learning-rate/learning-rate vs samples', learning_rate,
                               args.consumed_train_samples)
-            writer.add_scalar('learning-rate/learning-rate vs tokens', learning_rate,
+            writer.add_scalar_to_tb('learning-rate/learning-rate vs tokens', learning_rate,
                               args.consumed_train_tokens)
         if args.log_batch_size_to_tensorboard:
             writer.add_scalar('batch-size/batch-size', batch_size, iteration)
-            writer.add_scalar('batch-size/batch-size vs samples', batch_size,
+            writer.add_scalar_to_tb('batch-size/batch-size vs samples', batch_size,
                               args.consumed_train_samples)
-            writer.add_scalar('batch-size/batch-size vs tokens', batch_size,
+            writer.add_scalar_to_tb('batch-size/batch-size vs tokens', batch_size,
                               args.consumed_train_tokens)
         for key in loss_dict:
             writer.add_scalar(f"lm-loss-training/{key}", loss_dict[key], iteration)
-            writer.add_scalar(f"lm-loss-training/{key}" + ' vs samples', loss_dict[key],
+            writer.add_scalar_to_tb(f"lm-loss-training/{key}" + ' vs samples', loss_dict[key],
                               args.consumed_train_samples)
-            writer.add_scalar(f"lm-loss-training/{key}" + ' vs tokens', loss_dict[key],
+            writer.add_scalar_to_tb(f"lm-loss-training/{key}" + ' vs tokens', loss_dict[key],
                               args.consumed_train_tokens)
         if args.fp16 and loss_scale and args.log_loss_scale_to_tensorboard:
             writer.add_scalar('loss-scale/loss-scale', loss_scale, iteration)
-            writer.add_scalar('loss-scale/loss-scale vs samples', loss_scale,
+            writer.add_scalar_to_tb('loss-scale/loss-scale vs samples', loss_scale,
                               args.consumed_train_samples)
-            writer.add_scalar('loss-scale/loss-scale vs tokens', loss_scale,
+            writer.add_scalar_to_tb('loss-scale/loss-scale vs tokens', loss_scale,
                               args.consumed_train_tokens)
         if args.log_world_size_to_tensorboard:
             writer.add_scalar('world-size/world-size', args.world_size, iteration)
-            writer.add_scalar('world-size/world-size vs samples', args.world_size,
+            writer.add_scalar_to_tb('world-size/world-size vs samples', args.world_size,
                               args.consumed_train_samples)
-            writer.add_scalar('world-size/world-size vs tokens', args.world_size,
+            writer.add_scalar_to_tb('world-size/world-size vs tokens', args.world_size,
                               args.consumed_train_tokens)
         if grad_norm is not None:
             writer.add_scalar('grad-norm/grad-norm', grad_norm, iteration)
-            writer.add_scalar('grad-norm/grad-norm vs samples', grad_norm,
+            writer.add_scalar_to_tb('grad-norm/grad-norm vs samples', grad_norm,
                               args.consumed_train_samples)
-            writer.add_scalar('grad-norm/grad-norm vs tokens', grad_norm,
+            writer.add_scalar_to_tb('grad-norm/grad-norm vs tokens', grad_norm,
                               args.consumed_train_tokens)
         if num_zeros_in_grad is not None:
             writer.add_scalar('num-zeros/num-zeros', num_zeros_in_grad, iteration)
-            writer.add_scalar('num-zeros/num-zeros vs samples', num_zeros_in_grad,
+            writer.add_scalar_to_tb('num-zeros/num-zeros vs samples', num_zeros_in_grad,
                               args.consumed_train_samples)
-            writer.add_scalar('num-zeros/num-zeros vs tokens', num_zeros_in_grad,
+            writer.add_scalar_to_tb('num-zeros/num-zeros vs tokens', num_zeros_in_grad,
                               args.consumed_train_tokens)
         if params_norm is not None:
             writer.add_scalar('params-norm/params-norm', params_norm, iteration)
-            writer.add_scalar('params-norm/params-norm vs samples', params_norm,
+            writer.add_scalar_to_tb('params-norm/params-norm vs samples', params_norm,
                               args.consumed_train_samples)
-            writer.add_scalar('params-norm/params-norm vs tokens', params_norm,
+            writer.add_scalar_to_tb('params-norm/params-norm vs tokens', params_norm,
                               args.consumed_train_tokens)
         if hasattr(args, 'actual_seq_length'):
             writer.add_scalar('seqlen/actual_seq_length', args.actual_seq_length,
                               iteration)
-            writer.add_scalar('seqlen/actual_seq_length vs samples', args.actual_seq_length,
+            writer.add_scalar_to_tb('seqlen/actual_seq_length vs samples', args.actual_seq_length,
                               args.consumed_train_samples)
-            writer.add_scalar('seqlen/actual_seq_length vs tokens', args.actual_seq_length,
+            writer.add_scalar_to_tb('seqlen/actual_seq_length vs tokens', args.actual_seq_length,
                               args.consumed_train_tokens)
         if args.curriculum_learning_legacy or args.data_efficiency_curriculum_learning:
             writer.add_scalar('seqlen/curriculum_seqlen', args.curriculum_seqlen,
                               iteration)
-            writer.add_scalar('seqlen/curriculum_seqlen vs samples', args.curriculum_seqlen,
+            writer.add_scalar_to_tb('seqlen/curriculum_seqlen vs samples', args.curriculum_seqlen,
                               args.consumed_train_samples)
-            writer.add_scalar('seqlen/curriculum_seqlen vs tokens', args.curriculum_seqlen,
+            writer.add_scalar_to_tb('seqlen/curriculum_seqlen vs tokens', args.curriculum_seqlen,
                               args.consumed_train_tokens)
         if args.random_ltd:
             writer.add_scalar('seqlen/random_ltd_reserved_length', args.random_ltd_reserved_length,
                               iteration)
-            writer.add_scalar('seqlen/random_ltd_reserved_length vs samples', args.random_ltd_reserved_length,
+            writer.add_scalar_to_tb('seqlen/random_ltd_reserved_length vs samples', args.random_ltd_reserved_length,
                               args.consumed_train_samples)
-            writer.add_scalar('seqlen/random_ltd_reserved_length vs tokens', args.random_ltd_reserved_length,
+            writer.add_scalar_to_tb('seqlen/random_ltd_reserved_length vs tokens', args.random_ltd_reserved_length,
                               args.consumed_train_tokens)
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
@@ -1000,19 +1027,19 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                     group=mpu.get_pipeline_model_parallel_group())
 
             # print('step {} rank {} after sync opt_stats {}, {}'.format(iteration, torch.distributed.get_rank(), opt_stats_2, opt_stats))
-            if writer and is_last_rank():
-                writer.add_scalar('optimizer/variance_l2 vs tokens', opt_stats[0]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_sqrt_l2 vs tokens', opt_stats[1]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/momentum_l2 vs tokens', opt_stats[2]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/weight_l2 vs tokens', opt_stats[3]**0.5, args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_l1 vs tokens', opt_stats[4], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_sqrt_l1 vs tokens', opt_stats[5], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/momentum_l1 vs tokens', opt_stats[6], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/weight_l1 vs tokens', opt_stats[7], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_abs_max vs tokens', opt_stats_2[0], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/variance_sqrt_abs_max vs tokens', opt_stats_2[1], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/momentum_abs_max vs tokens', opt_stats_2[2], args.consumed_train_tokens)
-                writer.add_scalar('optimizer/weight_abs_max vs tokens', opt_stats_2[3], args.consumed_train_tokens)
+            if writer.is_enabled() and is_last_rank():
+                writer.add_scalar_to_tb('optimizer/variance_l2 vs tokens', opt_stats[0]**0.5, args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/variance_sqrt_l2 vs tokens', opt_stats[1]**0.5, args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/momentum_l2 vs tokens', opt_stats[2]**0.5, args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/weight_l2 vs tokens', opt_stats[3]**0.5, args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/variance_l1 vs tokens', opt_stats[4], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/variance_sqrt_l1 vs tokens', opt_stats[5], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/momentum_l1 vs tokens', opt_stats[6], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/weight_l1 vs tokens', opt_stats[7], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/variance_abs_max vs tokens', opt_stats_2[0], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/variance_sqrt_abs_max vs tokens', opt_stats_2[1], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/momentum_abs_max vs tokens', opt_stats_2[2], args.consumed_train_tokens)
+                writer.add_scalar_to_tb('optimizer/weight_abs_max vs tokens', opt_stats_2[3], args.consumed_train_tokens)
 
                 writer.add_scalar('optimizer/variance_l2', opt_stats[0]**0.5, iteration)
                 writer.add_scalar('optimizer/variance_sqrt_l2', opt_stats[1]**0.5, iteration)
@@ -1044,33 +1071,28 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         tokens_per_sec_per_replica = tokens_per_sec / args.data_parallel_size
         tokens_per_gpu_per_second = tokens_per_sec / args.world_size
         tokens_per_gpu_per_second_per_replica = tokens_per_gpu_per_second / args.data_parallel_size
-        if wandb is not None and getattr(wandb, 'run', None) is not None:
-            assert wandb.run is not None
-            wandb_metrics = {
-                'throughput/iteration-time': elapsed_time_per_iteration,  # 1000 ms / s
-                'throughput/samples_per_sec': samples_per_sec,
-                'throughput/samples_per_sec_per_replica': samples_per_sec_per_replica,
-                'throughput/tokens_per_sec': tokens_per_sec,
-                'throughput/tokens_per_sec_per_replica': tokens_per_sec_per_replica,
-                'throughput/tokens_per_gpu_per_sec': tokens_per_gpu_per_second,
-                'throughput/tokens_per_gpu_per_sec_per_replica': tokens_per_gpu_per_second_per_replica,
-                'throughput/tflops': tflops,
-                'throughput/approx_params_in_billions': approx_parameters_in_billions,
-                'throughput/elapsed_ms_per_iteration': elapsed_time_per_iteration,
-                'throughput/iteration': iteration,
-            }
+
+        if writer.is_enabled():
+            writer.add_scalar_to_wandb('throughput/iteration-time', elapsed_time_per_iteration, iteration)  # 1000 ms / s
+            writer.add_scalar_to_wandb('throughput/samples_per_sec', samples_per_sec, iteration)
+            writer.add_scalar_to_wandb('throughput/samples_per_sec_per_replica', samples_per_sec_per_replica, iteration)
+            writer.add_scalar_to_wandb('throughput/tokens_per_sec', tokens_per_sec, iteration)
+            writer.add_scalar_to_wandb('throughput/tokens_per_sec_per_replica', tokens_per_sec_per_replica, iteration)
+            writer.add_scalar_to_wandb('throughput/tokens_per_gpu_per_sec', tokens_per_gpu_per_second, iteration)
+            writer.add_scalar_to_wandb('throughput/tokens_per_gpu_per_sec_per_replica', tokens_per_gpu_per_second_per_replica, iteration)
+            writer.add_scalar_to_wandb('throughput/tflops', tflops, iteration)
+            writer.add_scalar_to_wandb('throughput/approx_params_in_billions', approx_parameters_in_billions, iteration)
+            writer.add_scalar_to_wandb('throughput/elapsed_ms_per_iteration', elapsed_time_per_iteration, iteration)
             if loss_dict is not None:
-                wandb_metrics |= {
-                    f'loss/{k}': v for k, v in loss_dict.items()
-                }
-                wandb_metrics |= {'loss/iteration': iteration}
-        if writer:
+                for k, v in loss_dict.items():
+                    writer.add_scalar_to_wandb(f'loss/{k}', v, iteration)
+
             if args.log_timers_to_tensorboard:
                 writer.add_scalar('iteration-time/iteration-time',
                                   elapsed_time_per_iteration, iteration)
-                writer.add_scalar('iteration-time/iteration-time vs samples',
+                writer.add_scalar_to_tb('iteration-time/iteration-time vs samples',
                                   elapsed_time_per_iteration, args.consumed_train_samples)
-                writer.add_scalar('iteration-time/iteration-time vs tokens',
+                writer.add_scalar_to_tb('iteration-time/iteration-time vs tokens',
                                   elapsed_time_per_iteration, args.consumed_train_tokens)
         log_string = ' iteration {:8d}/{:8d} |'.format(
             iteration, args.train_iters)
@@ -1082,21 +1104,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             elapsed_time_per_iteration * 1000.0)
         log_string += ' learning rate: {:.3E} |'.format(learning_rate)
         log_string += ' global batch size: {:5d} |'.format(batch_size)
-        if wandb is not None and getattr(wandb, 'run', None) is not None:
-            wandb_metrics |= {
-                'training/iteration': iteration,
-                'training/iteration_time': elapsed_time_per_iteration,
-                'training/iteration_time_vs_tokens': (
-                    (elapsed_time_per_iteration
-                        / args.consumed_train_tokens)
-                ),
-                'training/iteration_time_vs_samples': (
-                    (elapsed_time_per_iteration
-                        / args.consumed_train_samples),
-                ),
-                'training/consumed_samples': args.consumed_train_samples,
-                'training/consumed_tokens': args.consumed_train_tokens,
-            }
+
         for key in total_loss_dict:
             if key not in [advanced_iters_key, skipped_iters_key,
                            nan_iters_key]:
@@ -1105,8 +1113,6 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                 if avg > 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 total_loss_dict[key] = get_accelerator().FloatTensor([0.0])
-        if wandb is not None and getattr(wandb, 'run', None) is not None:
-            wandb.log(wandb_metrics)
         if loss_scale is not None:
             log_string += ' loss scale: {:.1f} |'.format(loss_scale)
         if grad_norm is not None:
@@ -1427,9 +1433,9 @@ def evaluate_and_print_results(prefix, forward_step_func,
     """Helper function to evaluate and dump results on screen."""
     args = get_args()
     if write_to_tensorboard:
-        writer = get_tensorboard_writer()
+        writer = interop_tool_logger(tb_writer=get_tensorboard_writer(), wandb_writer=get_wandb_writer())
     else:
-        writer = None
+        writer = interop_tool_logger()
 
     total_loss_dict, collected_non_loss_data = evaluate(
         forward_step_func, data_iterator, model,
@@ -1439,7 +1445,7 @@ def evaluate_and_print_results(prefix, forward_step_func,
         string += '{} value: {:.6E} | '.format(key, total_loss_dict[key].item())
         ppl = math.exp(min(20, total_loss_dict[key].item()))
         string += '{} PPL: {:.6E} | '.format(key, ppl)
-        if writer and is_last_rank():
+        if writer.is_enabled() and is_last_rank():
             data_type = 'test' if test else 'validation'
             writer.add_scalar(f'lm-loss-validation/{key} {data_type}',
                               total_loss_dict[key].item(),
@@ -1458,7 +1464,7 @@ def evaluate_and_print_results(prefix, forward_step_func,
                 writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs tokens',
                                   ppl, args.consumed_train_tokens)
 
-    if process_non_loss_data_func is not None and writer and is_last_rank():
+    if process_non_loss_data_func is not None and writer.is_enabled() and is_last_rank():
         process_non_loss_data_func(collected_non_loss_data, iteration, writer)
 
     length = len(string) + 1

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -7,11 +7,16 @@ import math
 import sys
 import time
 import json
+try:
+    import wandb
+except (ImportError, ModuleNotFoundError):
+    wandb = None
 # The earliest we can measure the start time.
 _TRAIN_START_TIME = time.time()
 import torch
 from collections import OrderedDict
 from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
+from enum import Enum
 
 from megatron import get_args
 from megatron import get_signal_handler
@@ -780,34 +785,62 @@ def train_step(forward_step_func, data_iterator,
     return {}, skipped_iter, grad_norm, num_zeros_in_grad
 
 
+class InteropLoggingTool(Enum):
+    TENSORBOARD = 1
+    WANDB = 2
+
+
 class interop_tool_logger:
     def __init__(self, tb_writer=None, wandb_writer=None):
         self.tb_writer = tb_writer
         self.wandb_writer = wandb_writer
+        self.custom_x_axis = []
+        self.custom_y_axis = {}
+        self.args = get_args()
+        if not hasattr(self.args, "logger_iteration"):
+            self.args.logger_iteration = 1
 
     def is_enabled(self):
         return self.tb_writer or self.wandb_writer
 
-    def add_scalar(self, key, scalar_value, step=None, tool_type='all'):
-        # tool_type is in ['all', 'wandb', 'tb']
-        if self.tb_writer and tool_type != 'wandb':
+    def add_scalar(self, key, scalar_value, step, custom_step_name=None, \
+                   tool_list=[InteropLoggingTool.TENSORBOARD, InteropLoggingTool.WANDB]):
+        if self.tb_writer and \
+            InteropLoggingTool.TENSORBOARD in tool_list:
             self.tb_writer.add_scalar(key, scalar_value, step)
 
-        if self.wandb_writer and tool_type != 'tb':
-            self.wandb_writer.log({key: scalar_value}, step)
+        if self.wandb_writer and \
+            InteropLoggingTool.WANDB in tool_list:
+            if not custom_step_name:
+                self.wandb_writer.log({key: scalar_value}, step=step)
+                if self.args.logger_iteration < step:
+                    # Updating iteration
+                    self.args.logger_iteration = step
 
-    def add_scalar_to_tb(self, key, scalar_value, step=None):
-        return self.add_scalar(key, scalar_value, step, tool_type='tb')
+            else:
+                if custom_step_name not in self.custom_x_axis:
+                    self.custom_x_axis.append(custom_step_name)
+                    wandb.define_metric(custom_step_name)
 
-    def add_scalar_to_wandb(self, key, scalar_value, step=None):
-        return self.add_scalar(key, scalar_value, step, tool_type='wandb')
+                if key not in self.custom_y_axis:
+                    self.custom_y_axis[key] = custom_step_name
+                    wandb.define_metric(key, step_metric=custom_step_name)
+
+                self.wandb_writer.log({key: scalar_value, custom_step_name: step}, \
+                                      step=self.args.logger_iteration)
+
+
+    def add_scalar_to_tb(self, key, scalar_value, step):
+        return self.add_scalar(key, scalar_value, step, None, [InteropLoggingTool.TENSORBOARD])
+
+    def add_scalar_to_wandb(self, key, scalar_value, step, custom_step_name=None):
+        return self.add_scalar(key, scalar_value, step, custom_step_name, [InteropLoggingTool.WANDB])
 
     def add_images(self, key, img_tensor, step=None):
         if self.tb_writer:
             self.tb_writer.add_images(key, img_tensor, step)
 
         if self.wandb_writer:
-            import wandb
             self.wandb_writer.log({key: wandb.Image(img_tensor)}, step)
 
 
@@ -820,7 +853,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     timers = get_timers()
     writer = interop_tool_logger(tb_writer=get_tensorboard_writer(), \
                                  wandb_writer=get_wandb_writer())
-
+    x_axis_samples = 'Samples'
+    x_axis_tokens = 'Tokens'
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = 'advanced iterations'
     skipped_iters_key = 'skipped iterations'
@@ -892,79 +926,79 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         timers.write(timers_to_log, writer, iteration,
                      normalizer=total_iterations)
     if writer.is_enabled() and (iteration % args.tensorboard_log_interval == 0):
-        writer.add_scalar_to_tb('steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples)
+        writer.add_scalar('steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples, x_axis_samples)
         writer.add_scalar('steps-vs-samples/y=samples,x=steps', args.consumed_train_samples, iteration)
-        writer.add_scalar_to_tb('steps-vs-tokens/y=steps,x=tokens', iteration, args.consumed_train_tokens)
+        writer.add_scalar('steps-vs-tokens/y=steps,x=tokens', iteration, args.consumed_train_tokens, x_axis_tokens)
         writer.add_scalar('steps-vs-tokens/y=tokens,x=steps', args.consumed_train_tokens, iteration)
         if args.log_learning_rate_to_tensorboard:
             writer.add_scalar('learning-rate/learning-rate', learning_rate, iteration)
-            writer.add_scalar_to_tb('learning-rate/learning-rate vs samples', learning_rate,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('learning-rate/learning-rate vs tokens', learning_rate,
-                              args.consumed_train_tokens)
+            writer.add_scalar('learning-rate/learning-rate vs samples', learning_rate,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('learning-rate/learning-rate vs tokens', learning_rate,
+                              args.consumed_train_tokens, x_axis_tokens)
         if args.log_batch_size_to_tensorboard:
             writer.add_scalar('batch-size/batch-size', batch_size, iteration)
-            writer.add_scalar_to_tb('batch-size/batch-size vs samples', batch_size,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('batch-size/batch-size vs tokens', batch_size,
-                              args.consumed_train_tokens)
+            writer.add_scalar('batch-size/batch-size vs samples', batch_size,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('batch-size/batch-size vs tokens', batch_size,
+                              args.consumed_train_tokens, x_axis_tokens)
         for key in loss_dict:
             writer.add_scalar(f"lm-loss-training/{key}", loss_dict[key], iteration)
-            writer.add_scalar_to_tb(f"lm-loss-training/{key}" + ' vs samples', loss_dict[key],
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb(f"lm-loss-training/{key}" + ' vs tokens', loss_dict[key],
-                              args.consumed_train_tokens)
+            writer.add_scalar(f"lm-loss-training/{key}" + ' vs samples', loss_dict[key],
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar(f"lm-loss-training/{key}" + ' vs tokens', loss_dict[key],
+                              args.consumed_train_tokens, x_axis_tokens)
         if args.fp16 and loss_scale and args.log_loss_scale_to_tensorboard:
             writer.add_scalar('loss-scale/loss-scale', loss_scale, iteration)
-            writer.add_scalar_to_tb('loss-scale/loss-scale vs samples', loss_scale,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('loss-scale/loss-scale vs tokens', loss_scale,
-                              args.consumed_train_tokens)
+            writer.add_scalar('loss-scale/loss-scale vs samples', loss_scale,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('loss-scale/loss-scale vs tokens', loss_scale,
+                              args.consumed_train_tokens, x_axis_tokens)
         if args.log_world_size_to_tensorboard:
             writer.add_scalar('world-size/world-size', args.world_size, iteration)
-            writer.add_scalar_to_tb('world-size/world-size vs samples', args.world_size,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('world-size/world-size vs tokens', args.world_size,
-                              args.consumed_train_tokens)
+            writer.add_scalar('world-size/world-size vs samples', args.world_size,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('world-size/world-size vs tokens', args.world_size,
+                              args.consumed_train_tokens, x_axis_tokens)
         if grad_norm is not None:
             writer.add_scalar('grad-norm/grad-norm', grad_norm, iteration)
-            writer.add_scalar_to_tb('grad-norm/grad-norm vs samples', grad_norm,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('grad-norm/grad-norm vs tokens', grad_norm,
-                              args.consumed_train_tokens)
+            writer.add_scalar('grad-norm/grad-norm vs samples', grad_norm,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('grad-norm/grad-norm vs tokens', grad_norm,
+                              args.consumed_train_tokens, x_axis_tokens)
         if num_zeros_in_grad is not None:
             writer.add_scalar('num-zeros/num-zeros', num_zeros_in_grad, iteration)
-            writer.add_scalar_to_tb('num-zeros/num-zeros vs samples', num_zeros_in_grad,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('num-zeros/num-zeros vs tokens', num_zeros_in_grad,
-                              args.consumed_train_tokens)
+            writer.add_scalar('num-zeros/num-zeros vs samples', num_zeros_in_grad,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('num-zeros/num-zeros vs tokens', num_zeros_in_grad,
+                              args.consumed_train_tokens, x_axis_tokens)
         if params_norm is not None:
             writer.add_scalar('params-norm/params-norm', params_norm, iteration)
-            writer.add_scalar_to_tb('params-norm/params-norm vs samples', params_norm,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('params-norm/params-norm vs tokens', params_norm,
-                              args.consumed_train_tokens)
+            writer.add_scalar('params-norm/params-norm vs samples', params_norm,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('params-norm/params-norm vs tokens', params_norm,
+                              args.consumed_train_tokens, x_axis_tokens)
         if hasattr(args, 'actual_seq_length'):
             writer.add_scalar('seqlen/actual_seq_length', args.actual_seq_length,
                               iteration)
-            writer.add_scalar_to_tb('seqlen/actual_seq_length vs samples', args.actual_seq_length,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('seqlen/actual_seq_length vs tokens', args.actual_seq_length,
-                              args.consumed_train_tokens)
+            writer.add_scalar('seqlen/actual_seq_length vs samples', args.actual_seq_length,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('seqlen/actual_seq_length vs tokens', args.actual_seq_length,
+                              args.consumed_train_tokens, x_axis_tokens)
         if args.curriculum_learning_legacy or args.data_efficiency_curriculum_learning:
             writer.add_scalar('seqlen/curriculum_seqlen', args.curriculum_seqlen,
                               iteration)
-            writer.add_scalar_to_tb('seqlen/curriculum_seqlen vs samples', args.curriculum_seqlen,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('seqlen/curriculum_seqlen vs tokens', args.curriculum_seqlen,
-                              args.consumed_train_tokens)
+            writer.add_scalar('seqlen/curriculum_seqlen vs samples', args.curriculum_seqlen,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('seqlen/curriculum_seqlen vs tokens', args.curriculum_seqlen,
+                              args.consumed_train_tokens, x_axis_tokens)
         if args.random_ltd:
             writer.add_scalar('seqlen/random_ltd_reserved_length', args.random_ltd_reserved_length,
                               iteration)
-            writer.add_scalar_to_tb('seqlen/random_ltd_reserved_length vs samples', args.random_ltd_reserved_length,
-                              args.consumed_train_samples)
-            writer.add_scalar_to_tb('seqlen/random_ltd_reserved_length vs tokens', args.random_ltd_reserved_length,
-                              args.consumed_train_tokens)
+            writer.add_scalar('seqlen/random_ltd_reserved_length vs samples', args.random_ltd_reserved_length,
+                              args.consumed_train_samples, x_axis_samples)
+            writer.add_scalar('seqlen/random_ltd_reserved_length vs tokens', args.random_ltd_reserved_length,
+                              args.consumed_train_tokens, x_axis_tokens)
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
@@ -1028,18 +1062,18 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
 
             # print('step {} rank {} after sync opt_stats {}, {}'.format(iteration, torch.distributed.get_rank(), opt_stats_2, opt_stats))
             if writer.is_enabled() and is_last_rank():
-                writer.add_scalar_to_tb('optimizer/variance_l2 vs tokens', opt_stats[0]**0.5, args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/variance_sqrt_l2 vs tokens', opt_stats[1]**0.5, args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/momentum_l2 vs tokens', opt_stats[2]**0.5, args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/weight_l2 vs tokens', opt_stats[3]**0.5, args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/variance_l1 vs tokens', opt_stats[4], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/variance_sqrt_l1 vs tokens', opt_stats[5], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/momentum_l1 vs tokens', opt_stats[6], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/weight_l1 vs tokens', opt_stats[7], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/variance_abs_max vs tokens', opt_stats_2[0], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/variance_sqrt_abs_max vs tokens', opt_stats_2[1], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/momentum_abs_max vs tokens', opt_stats_2[2], args.consumed_train_tokens)
-                writer.add_scalar_to_tb('optimizer/weight_abs_max vs tokens', opt_stats_2[3], args.consumed_train_tokens)
+                writer.add_scalar('optimizer/variance_l2 vs tokens', opt_stats[0]**0.5, args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/variance_sqrt_l2 vs tokens', opt_stats[1]**0.5, args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/momentum_l2 vs tokens', opt_stats[2]**0.5, args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/weight_l2 vs tokens', opt_stats[3]**0.5, args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/variance_l1 vs tokens', opt_stats[4], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/variance_sqrt_l1 vs tokens', opt_stats[5], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/momentum_l1 vs tokens', opt_stats[6], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/weight_l1 vs tokens', opt_stats[7], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/variance_abs_max vs tokens', opt_stats_2[0], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/variance_sqrt_abs_max vs tokens', opt_stats_2[1], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/momentum_abs_max vs tokens', opt_stats_2[2], args.consumed_train_tokens, x_axis_tokens)
+                writer.add_scalar('optimizer/weight_abs_max vs tokens', opt_stats_2[3], args.consumed_train_tokens, x_axis_tokens)
 
                 writer.add_scalar('optimizer/variance_l2', opt_stats[0]**0.5, iteration)
                 writer.add_scalar('optimizer/variance_sqrt_l2', opt_stats[1]**0.5, iteration)
@@ -1090,10 +1124,10 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             if args.log_timers_to_tensorboard:
                 writer.add_scalar('iteration-time/iteration-time',
                                   elapsed_time_per_iteration, iteration)
-                writer.add_scalar_to_tb('iteration-time/iteration-time vs samples',
-                                  elapsed_time_per_iteration, args.consumed_train_samples)
-                writer.add_scalar_to_tb('iteration-time/iteration-time vs tokens',
-                                  elapsed_time_per_iteration, args.consumed_train_tokens)
+                writer.add_scalar('iteration-time/iteration-time vs samples',
+                                  elapsed_time_per_iteration, args.consumed_train_samples, x_axis_samples)
+                writer.add_scalar('iteration-time/iteration-time vs tokens',
+                                  elapsed_time_per_iteration, args.consumed_train_tokens, x_axis_tokens)
         log_string = ' iteration {:8d}/{:8d} |'.format(
             iteration, args.train_iters)
         log_string += ' consumed samples: {:12d} |'.format(

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1470,6 +1470,8 @@ def evaluate_and_print_results(prefix, forward_step_func,
         writer = interop_tool_logger(tb_writer=get_tensorboard_writer(), wandb_writer=get_wandb_writer())
     else:
         writer = interop_tool_logger()
+    x_axis_samples = 'Samples'
+    x_axis_tokens = 'Tokens'
 
     total_loss_dict, collected_non_loss_data = evaluate(
         forward_step_func, data_iterator, model,
@@ -1486,17 +1488,19 @@ def evaluate_and_print_results(prefix, forward_step_func,
                               iteration)
             writer.add_scalar(f'lm-loss-validation/{key} {data_type} vs samples',
                               total_loss_dict[key].item(),
-                              args.consumed_train_samples)
+                              args.consumed_train_samples,
+                              x_axis_samples)
             writer.add_scalar(f'lm-loss-validation/{key} {data_type} vs tokens',
                               total_loss_dict[key].item(),
-                              args.consumed_train_tokens)
+                              args.consumed_train_tokens,
+                              x_axis_tokens)
             if args.log_validation_ppl_to_tensorboard:
                 writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl', ppl,
                                   iteration)
                 writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs samples',
-                                  ppl, args.consumed_train_samples)
+                                  ppl, args.consumed_train_samples, x_axis_samples)
                 writer.add_scalar(f'lm-loss-validation/{key} {data_type} ppl vs tokens',
-                                  ppl, args.consumed_train_tokens)
+                                  ppl, args.consumed_train_tokens, x_axis_tokens)
 
     if process_non_loss_data_func is not None and writer.is_enabled() and is_last_rank():
         process_non_loss_data_func(collected_non_loss_data, iteration, writer)


### PR DESCRIPTION
This patch aims to enable wandb initilization and make it more unified with old tensorboard code style.
With this patch enabled, we can log and visilize our training procedure on wandb panel.
Here is the example figure

![Screenshot 2024-07-09 110418](https://github.com/microsoft/Megatron-DeepSpeed/assets/96406262/28025924-7b6e-432a-b9d7-b75f532d1d49)
![Screenshot 2024-07-09 110505](https://github.com/microsoft/Megatron-DeepSpeed/assets/96406262/2e0ca50b-e819-4012-ba10-3e155ecde3d2)
