### PR TITLE
[wandb] disable wandb more gracefully

### DIFF
--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -165,16 +165,15 @@ def _set_wandb_writer(args):
     global _GLOBAL_WANDB_WRITER
     _ensure_var_is_not_initialized(_GLOBAL_WANDB_WRITER,
                                    'wandb writer')
-    getattr(args, 'wandb_project', '')
-    getattr(args, 'wandb_exp_name', '')
 
     if args.rank == (args.world_size - 1):
-        if args.wandb_project == '' or \
-            args.wandb_exp_name == '':
+        if getattr(args, 'wandb_project', '') == '' and \
+           getattr(args, 'wandb_exp_name', '') == '':
             print('WARNING: WANDB writing requested but no legit wandb '
                   'project or experiment name provided, '
-                  'therefore WANDB logs will be written '
-                  'according to random generated project or experiment name.', flush=True)
+                  'therefore no WANDB logs will be written.'
+                  , flush=True)
+            return
 
         try:
             import wandb


### PR DESCRIPTION
Currently we can only disable wandb by removing its package (pip uninstall wandb). It is not graceful if users have wandb installed in their dev environment but dont want to use wandb. With this patch, wandb feature can be disabled if both exp or project name are not specified.