### PR TITLE
fix init issue for silently ignoring the deepspeed config

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -185,6 +185,7 @@ def setup_deepspeed_random_and_activation_checkpointing(args):
 
     deepspeed.checkpointing.configure(
         mpu,
+        deepspeed_config=args.deepspeed_config,
         partition_activations=args.partition_activations,
         contiguous_checkpointing=args.contigious_checkpointing,
         num_checkpoints=num_layers,


### PR DESCRIPTION
This PR addresses the issue related to `deepspeed-activation-checkpointing`. Previously, when users want to use this feature, the corresponding configs, such as `partition_activations` and `cpu_checkpointing`, will be silently ignored. due to those config are not pass to the function.