### PR TITLE
Fix AttributeError in hf2megads weight converter

### DIFF
--- a/tools/hf2megads_weight_converter.py
+++ b/tools/hf2megads_weight_converter.py
@@ -5,6 +5,7 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import torch.distributed
 from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
+from torch.optim import Optimizer
 from megatron import print_rank_0, get_tokenizer, get_args
 from megatron.core import mpu
 from megatron.core import tensor_parallel
@@ -22,6 +23,21 @@ import deepspeed
 import copy
 from pathlib import Path
 
+
+class DummyOptimizerWithStateDict(Optimizer):
+    """Dummy optimizer that inherits from torch.optim.Optimizer and provides state_dict method"""
+    def __init__(self):
+        self.param_groups = []
+        self.state = {}
+
+    def step(self, closure=None):
+        pass
+
+    def state_dict(self):
+        return {'state': self.state, 'param_groups': self.param_groups}
+
+    def load_state_dict(self, state_dict):
+        pass
 
 
 def add_extra_args(parser):
@@ -504,9 +520,10 @@ def convert_ckpt():
 
     #init model and save
     print_rank_0(f"before deepspeed init")
+    dummy_optimizer = DummyOptimizerWithStateDict()
     ds_engine, _, _, _ = deepspeed.initialize(
         model=ds_model,
-        optimizer=None,
+        optimizer=dummy_optimizer,
         args=args,
         lr_scheduler=None,
         mpu=mpu if args.no_pipeline_parallel else None)


### PR DESCRIPTION
This PR is aiming to address https://github.com/deepspeedai/Megatron-DeepSpeed/issues/482 by adding `DummyOptimizerWithStateDict` class that inherits from `torch.optim.Optimizer` to resolve the AttributeError that occurs when DeepSpeed tries to save checkpoints during weight conversion.

The built-in DummyOptim created when passing `optimizer=None` to `deepspeed.initialize()` lacks a `state_dict()` method. Additionally, DeepSpeed validates that the optimizer is an instance of expected types (Optimizer, None, or Callable).

This fix provides a custom optimizer that:
- Inherits from `torch.optim.Optimizer` to pass DeepSpeed's type check
- Implements required methods: `step()`, `state_dict()`, and `load_state_dict()`
- Returns empty state since optimizer state is not needed during conversion
